### PR TITLE
feat(tasks): 任務 CRUD 功能

### DIFF
--- a/src/__tests__/tasks-store.test.ts
+++ b/src/__tests__/tasks-store.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useTasksStore } from '@/stores/tasks'
+import { useAuthStore } from '@/stores/auth'
+import type { Task } from '@/types'
+
+const mockFetch = vi.fn()
+
+const mockTask: Task = {
+  id: 1,
+  title: 'Test Task',
+  description: 'Task description',
+  project_id: 1,
+  column_id: 1,
+  swimlane_id: 1,
+  position: 1,
+  is_active: true,
+  color_id: 'blue',
+  priority: 0,
+  owner_id: 1,
+  creator_id: 1,
+  date_creation: 1704067200,
+  date_modification: 1704067200
+}
+
+describe('Tasks Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.stubGlobal('fetch', mockFetch)
+    mockFetch.mockReset()
+
+    // Setup auth store with credentials
+    const authStore = useAuthStore()
+    authStore.apiUrl = 'http://localhost/jsonrpc.php'
+    authStore.username = 'admin'
+    authStore.token = 'admin'
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('initial state', () => {
+    it('should have null currentTask', () => {
+      const store = useTasksStore()
+
+      expect(store.currentTask).toBeNull()
+      expect(store.isLoading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+  })
+
+  describe('fetchTask', () => {
+    it('should fetch and store task', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockTask
+        })
+      })
+
+      const store = useTasksStore()
+      await store.fetchTask(1)
+
+      expect(store.currentTask).toEqual(mockTask)
+      expect(store.isLoading).toBe(false)
+    })
+
+    it('should handle fetch error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const store = useTasksStore()
+      await store.fetchTask(1)
+
+      expect(store.currentTask).toBeNull()
+      expect(store.error).toBe('Network error')
+    })
+  })
+
+  describe('createTask', () => {
+    it('should create task and return id', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: 5
+        })
+      })
+
+      const store = useTasksStore()
+      const taskId = await store.createTask({
+        project_id: 1,
+        title: 'New Task',
+        color_id: 'blue'
+      })
+
+      expect(taskId).toBe(5)
+    })
+
+    it('should throw on create error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Create failed'))
+
+      const store = useTasksStore()
+
+      await expect(
+        store.createTask({
+          project_id: 1,
+          title: 'New Task'
+        })
+      ).rejects.toThrow('Create failed')
+    })
+  })
+
+  describe('updateTask', () => {
+    it('should update task', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useTasksStore()
+      const result = await store.updateTask(1, { title: 'Updated Title' })
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('closeTask', () => {
+    it('should close task', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useTasksStore()
+      const result = await store.closeTask(1)
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('openTask', () => {
+    it('should open task', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useTasksStore()
+      const result = await store.openTask(1)
+
+      expect(result).toBe(true)
+    })
+  })
+})

--- a/src/components/TaskFormModal.vue
+++ b/src/components/TaskFormModal.vue
@@ -1,0 +1,216 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { BoardColumn } from '@/stores/board'
+
+const props = defineProps<{
+  isOpen: boolean
+  projectId: number
+  columns: BoardColumn[]
+  defaultColumnId?: number
+}>()
+
+const emit = defineEmits<{
+  close: []
+  submit: [data: {
+    title: string
+    description: string
+    color_id: string
+    column_id: number
+  }]
+}>()
+
+const title = ref('')
+const description = ref('')
+const colorId = ref('yellow')
+const columnId = ref<number>(0)
+const isSubmitting = ref(false)
+
+const colors = [
+  { id: 'yellow', name: '黃色', class: 'bg-yellow-500' },
+  { id: 'blue', name: '藍色', class: 'bg-blue-500' },
+  { id: 'green', name: '綠色', class: 'bg-green-500' },
+  { id: 'purple', name: '紫色', class: 'bg-purple-500' },
+  { id: 'red', name: '紅色', class: 'bg-red-500' },
+  { id: 'orange', name: '橘色', class: 'bg-orange-500' },
+  { id: 'grey', name: '灰色', class: 'bg-gray-500' },
+  { id: 'cyan', name: '青色', class: 'bg-cyan-500' }
+]
+
+const isValid = computed(() => title.value.trim().length > 0)
+
+watch(() => props.isOpen, (open) => {
+  if (open) {
+    title.value = ''
+    description.value = ''
+    colorId.value = 'yellow'
+    columnId.value = props.defaultColumnId || props.columns[0]?.id || 0
+  }
+})
+
+watch(() => props.defaultColumnId, (id) => {
+  if (id) {
+    columnId.value = id
+  }
+})
+
+const handleSubmit = () => {
+  if (!isValid.value || isSubmitting.value) return
+
+  isSubmitting.value = true
+  emit('submit', {
+    title: title.value.trim(),
+    description: description.value.trim(),
+    color_id: colorId.value,
+    column_id: columnId.value
+  })
+}
+
+const handleClose = () => {
+  if (!isSubmitting.value) {
+    emit('close')
+  }
+}
+
+defineExpose({
+  setSubmitting: (value: boolean) => {
+    isSubmitting.value = value
+  }
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="isOpen"
+      class="fixed inset-0 z-50 overflow-y-auto"
+    >
+      <!-- Backdrop -->
+      <div
+        class="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+        @click="handleClose"
+      ></div>
+
+      <!-- Modal -->
+      <div class="flex min-h-full items-center justify-center p-4">
+        <div
+          class="relative bg-white rounded-lg shadow-xl w-full max-w-lg"
+          @click.stop
+        >
+          <!-- Header -->
+          <div class="flex items-center justify-between p-4 border-b">
+            <h3 class="text-lg font-semibold text-gray-900">新增任務</h3>
+            <button
+              @click="handleClose"
+              class="text-gray-400 hover:text-gray-500"
+              :disabled="isSubmitting"
+            >
+              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Form -->
+          <form @submit.prevent="handleSubmit" class="p-4 space-y-4">
+            <!-- Title -->
+            <div>
+              <label for="title" class="block text-sm font-medium text-gray-700 mb-1">
+                標題 <span class="text-red-500">*</span>
+              </label>
+              <input
+                id="title"
+                v-model="title"
+                type="text"
+                required
+                :disabled="isSubmitting"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100"
+                placeholder="輸入任務標題"
+              />
+            </div>
+
+            <!-- Description -->
+            <div>
+              <label for="description" class="block text-sm font-medium text-gray-700 mb-1">
+                描述
+              </label>
+              <textarea
+                id="description"
+                v-model="description"
+                rows="3"
+                :disabled="isSubmitting"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100"
+                placeholder="輸入任務描述（選填）"
+              ></textarea>
+            </div>
+
+            <!-- Column -->
+            <div>
+              <label for="column" class="block text-sm font-medium text-gray-700 mb-1">
+                欄位
+              </label>
+              <select
+                id="column"
+                v-model="columnId"
+                :disabled="isSubmitting"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100"
+              >
+                <option
+                  v-for="column in columns"
+                  :key="column.id"
+                  :value="column.id"
+                >
+                  {{ column.title }}
+                </option>
+              </select>
+            </div>
+
+            <!-- Color -->
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-2">
+                顏色
+              </label>
+              <div class="flex flex-wrap gap-2">
+                <button
+                  v-for="color in colors"
+                  :key="color.id"
+                  type="button"
+                  @click="colorId = color.id"
+                  :disabled="isSubmitting"
+                  :class="[
+                    'w-8 h-8 rounded-full transition-transform',
+                    color.class,
+                    colorId === color.id ? 'ring-2 ring-offset-2 ring-gray-400 scale-110' : 'hover:scale-105'
+                  ]"
+                  :title="color.name"
+                ></button>
+              </div>
+            </div>
+
+            <!-- Actions -->
+            <div class="flex justify-end gap-3 pt-4 border-t">
+              <button
+                type="button"
+                @click="handleClose"
+                :disabled="isSubmitting"
+                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md disabled:opacity-50"
+              >
+                取消
+              </button>
+              <button
+                type="submit"
+                :disabled="!isValid || isSubmitting"
+                class="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+              >
+                <svg v-if="isSubmitting" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                {{ isSubmitting ? '建立中...' : '建立任務' }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/stores/tasks.ts
+++ b/src/stores/tasks.ts
@@ -1,0 +1,109 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useAuthStore } from './auth'
+import type { Task } from '@/types'
+
+export interface CreateTaskParams {
+  project_id: number
+  title: string
+  description?: string
+  color_id?: string
+  column_id?: number
+  swimlane_id?: number
+  owner_id?: number
+  category_id?: number
+  date_due?: string
+  priority?: number
+  score?: number
+  time_estimated?: number
+}
+
+export interface UpdateTaskParams {
+  title?: string
+  description?: string
+  color_id?: string
+  column_id?: number
+  swimlane_id?: number
+  owner_id?: number
+  category_id?: number
+  date_due?: string
+  priority?: number
+  score?: number
+  time_estimated?: number
+}
+
+export const useTasksStore = defineStore('tasks', () => {
+  const currentTask = ref<Task | null>(null)
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchTask(taskId: number): Promise<void> {
+    const authStore = useAuthStore()
+
+    isLoading.value = true
+    error.value = null
+
+    try {
+      const client = authStore.getClient()
+      const task = await client.call<Task>('getTask', { task_id: taskId })
+      currentTask.value = task
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : '載入任務失敗'
+      currentTask.value = null
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function createTask(params: CreateTaskParams): Promise<number> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const taskId = await client.call<number>('createTask', { ...params })
+    return taskId
+  }
+
+  async function updateTask(taskId: number, params: UpdateTaskParams): Promise<boolean> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<boolean>('updateTask', {
+      id: taskId,
+      ...params
+    } as Record<string, unknown>)
+    return result
+  }
+
+  async function closeTask(taskId: number): Promise<boolean> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<boolean>('closeTask', { task_id: taskId })
+    return result
+  }
+
+  async function openTask(taskId: number): Promise<boolean> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<boolean>('openTask', { task_id: taskId })
+    return result
+  }
+
+  function clearCurrentTask(): void {
+    currentTask.value = null
+    error.value = null
+  }
+
+  return {
+    currentTask,
+    isLoading,
+    error,
+    fetchTask,
+    createTask,
+    updateTask,
+    closeTask,
+    openTask,
+    clearCurrentTask
+  }
+})

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -1,17 +1,25 @@
 <script setup lang="ts">
-import { onMounted, watch } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useBoardStore } from '@/stores/board'
+import { useTasksStore } from '@/stores/tasks'
 import TaskCard from '@/components/TaskCard.vue'
+import TaskFormModal from '@/components/TaskFormModal.vue'
 import type { Task } from '@/types'
 
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
 const boardStore = useBoardStore()
+const tasksStore = useTasksStore()
 
 const projectId = Number(route.params.id)
+
+// Modal state
+const showTaskModal = ref(false)
+const defaultColumnId = ref<number>(0)
+const taskModalRef = ref<InstanceType<typeof TaskFormModal> | null>(null)
 
 onMounted(() => {
   boardStore.fetchBoard(projectId)
@@ -35,6 +43,36 @@ const goToProjects = () => {
 const handleTaskClick = (task: Task) => {
   console.log('Task clicked:', task.id)
   // TODO: Open task detail modal
+}
+
+const openAddTaskModal = (columnId: number) => {
+  defaultColumnId.value = columnId
+  showTaskModal.value = true
+}
+
+const handleCreateTask = async (data: {
+  title: string
+  description: string
+  color_id: string
+  column_id: number
+}) => {
+  try {
+    await tasksStore.createTask({
+      project_id: projectId,
+      title: data.title,
+      description: data.description || undefined,
+      color_id: data.color_id,
+      column_id: data.column_id
+    })
+    showTaskModal.value = false
+    // Refresh board
+    await boardStore.fetchBoard(projectId)
+  } catch (error) {
+    console.error('Failed to create task:', error)
+    alert('建立任務失敗')
+  } finally {
+    taskModalRef.value?.setSubmitting(false)
+  }
 }
 </script>
 
@@ -109,6 +147,7 @@ const handleTaskClick = (task: Task) => {
               </span>
             </div>
             <button
+              @click="openAddTaskModal(column.id)"
               class="text-gray-500 hover:text-gray-700"
               title="新增任務"
             >
@@ -138,5 +177,16 @@ const handleTaskClick = (task: Task) => {
         </div>
       </div>
     </main>
+
+    <!-- Task Form Modal -->
+    <TaskFormModal
+      ref="taskModalRef"
+      :is-open="showTaskModal"
+      :project-id="projectId"
+      :columns="boardStore.columns"
+      :default-column-id="defaultColumnId"
+      @close="showTaskModal = false"
+      @submit="handleCreateTask"
+    />
   </div>
 </template>


### PR DESCRIPTION
## Summary

- 建立 Tasks Store，提供任務 CRUD 操作（createTask, updateTask, closeTask, openTask, fetchTask）
- 建立 TaskFormModal 元件，支援新增任務（標題、描述、欄位選擇、顏色選擇）
- 整合 TaskFormModal 至 BoardView，點擊欄位的 + 按鈕可新增任務
- 新增 tasks store 單元測試（8 項測試）

## Files Changed

- `src/stores/tasks.ts` - Tasks store 實作
- `src/__tests__/tasks-store.test.ts` - Tasks store 測試
- `src/components/TaskFormModal.vue` - 任務表單 Modal 元件
- `src/views/BoardView.vue` - 整合任務建立功能

## Test Plan

- [x] 所有單元測試通過（63 項）
- [x] TypeScript 類型檢查通過
- [ ] 手動測試：開啟看板，點擊欄位 + 按鈕新增任務
- [ ] 手動測試：填寫標題、描述、選擇顏色後建立任務
- [ ] 手動測試：任務建立後顯示於對應欄位

Closes #11