### PR TITLE
feat(tasks): 任務詳情頁

### DIFF
--- a/src/__tests__/TaskDetailModal.test.ts
+++ b/src/__tests__/TaskDetailModal.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import TaskDetailModal from '@/components/TaskDetailModal.vue'
+import { useAuthStore } from '@/stores/auth'
+import type { Task } from '@/types'
+
+const mockFetch = vi.fn()
+
+const mockTask: Task = {
+  id: 1,
+  title: '測試任務',
+  description: '任務描述內容',
+  project_id: 1,
+  column_id: 1,
+  swimlane_id: 1,
+  position: 1,
+  is_active: true,
+  color_id: 'blue',
+  priority: 2,
+  owner_id: 1,
+  creator_id: 1,
+  date_creation: 1704067200,
+  date_modification: 1704153600,
+  date_due: 1704240000
+}
+
+const mockColumns = [
+  { id: 1, title: '待辦', position: 1, project_id: 1, task_limit: 0, nb_tasks: 2, tasks: [] },
+  { id: 2, title: '進行中', position: 2, project_id: 1, task_limit: 5, nb_tasks: 1, tasks: [] },
+  { id: 3, title: '完成', position: 3, project_id: 1, task_limit: 0, nb_tasks: 0, tasks: [] }
+]
+
+describe('TaskDetailModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.stubGlobal('fetch', mockFetch)
+    mockFetch.mockReset()
+
+    // Setup auth store with credentials
+    const authStore = useAuthStore()
+    authStore.apiUrl = 'http://localhost/jsonrpc.php'
+    authStore.username = 'admin'
+    authStore.token = 'admin'
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('rendering', () => {
+    it('should not render when closed', () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: false,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      expect(wrapper.find('[data-testid="task-detail-modal"]').exists()).toBe(false)
+    })
+
+    it('should render when open', () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      expect(wrapper.find('[data-testid="task-detail-modal"]').exists()).toBe(true)
+    })
+
+    it('should display task title', () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      expect(wrapper.text()).toContain('測試任務')
+    })
+
+    it('should display task ID', () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      expect(wrapper.text()).toContain('#1')
+    })
+
+    it('should display task description', () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      expect(wrapper.text()).toContain('任務描述內容')
+    })
+
+    it('should display task status as active', () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      expect(wrapper.text()).toContain('開啟')
+    })
+
+    it('should display task status as closed', () => {
+      const closedTask = { ...mockTask, is_active: false }
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: closedTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      expect(wrapper.text()).toContain('已關閉')
+    })
+  })
+
+  describe('editing', () => {
+    it('should enter edit mode when clicking edit button', async () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      await wrapper.find('[data-testid="edit-title-btn"]').trigger('click')
+      expect(wrapper.find('[data-testid="title-input"]').exists()).toBe(true)
+    })
+
+    it('should emit update event when saving title', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      await wrapper.find('[data-testid="edit-title-btn"]').trigger('click')
+      const input = wrapper.find('[data-testid="title-input"]')
+      await input.setValue('更新的標題')
+      await wrapper.find('[data-testid="save-title-btn"]').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.emitted('updated')).toBeTruthy()
+    })
+  })
+
+  describe('actions', () => {
+    it('should emit close event when clicking close button', async () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      await wrapper.find('[data-testid="close-modal-btn"]').trigger('click')
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    it('should close task when clicking close task button', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      await wrapper.find('[data-testid="close-task-btn"]').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.emitted('updated')).toBeTruthy()
+    })
+
+    it('should open task when clicking open task button', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const closedTask = { ...mockTask, is_active: false }
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: closedTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      await wrapper.find('[data-testid="open-task-btn"]').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.emitted('updated')).toBeTruthy()
+    })
+  })
+
+  describe('color selection', () => {
+    it('should display color options', () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      expect(wrapper.find('[data-testid="color-selector"]').exists()).toBe(true)
+    })
+
+    it('should update color when clicking a color', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      await wrapper.find('[data-testid="color-red"]').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.emitted('updated')).toBeTruthy()
+    })
+  })
+
+  describe('dates', () => {
+    it('should display creation date', () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      // date_creation: 1704067200 = 2024-01-01
+      expect(wrapper.text()).toContain('2024')
+    })
+
+    it('should display due date if set', () => {
+      const wrapper = mount(TaskDetailModal, {
+        props: {
+          isOpen: true,
+          task: mockTask,
+          columns: mockColumns,
+          projectId: 1
+        },
+        global: {
+          stubs: {
+            teleport: true
+          }
+        }
+      })
+
+      // Task has date_due set
+      expect(wrapper.find('[data-testid="due-date"]').exists()).toBe(true)
+    })
+  })
+})

--- a/src/components/TaskDetailModal.vue
+++ b/src/components/TaskDetailModal.vue
@@ -1,0 +1,410 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useTasksStore } from '@/stores/tasks'
+import type { BoardColumn } from '@/stores/board'
+import type { Task } from '@/types'
+
+const props = defineProps<{
+  isOpen: boolean
+  task: Task | null
+  columns: BoardColumn[]
+  projectId: number
+}>()
+
+const emit = defineEmits<{
+  close: []
+  updated: []
+}>()
+
+const tasksStore = useTasksStore()
+
+// Edit states
+const isEditingTitle = ref(false)
+const isEditingDescription = ref(false)
+const editTitle = ref('')
+const editDescription = ref('')
+const isUpdating = ref(false)
+
+const colors = [
+  { id: 'yellow', name: '黃色', class: 'bg-yellow-500' },
+  { id: 'blue', name: '藍色', class: 'bg-blue-500' },
+  { id: 'green', name: '綠色', class: 'bg-green-500' },
+  { id: 'purple', name: '紫色', class: 'bg-purple-500' },
+  { id: 'red', name: '紅色', class: 'bg-red-500' },
+  { id: 'orange', name: '橘色', class: 'bg-orange-500' },
+  { id: 'grey', name: '灰色', class: 'bg-gray-500' },
+  { id: 'cyan', name: '青色', class: 'bg-cyan-500' },
+  { id: 'lime', name: '萊姆綠', class: 'bg-lime-500' },
+  { id: 'pink', name: '粉紅', class: 'bg-pink-500' },
+  { id: 'teal', name: '藍綠', class: 'bg-teal-500' },
+  { id: 'amber', name: '琥珀', class: 'bg-amber-500' },
+  { id: 'brown', name: '棕色', class: 'bg-amber-800' },
+  { id: 'deep_orange', name: '深橘', class: 'bg-orange-700' },
+  { id: 'dark_grey', name: '深灰', class: 'bg-gray-700' },
+  { id: 'white', name: '白色', class: 'bg-white border border-gray-300' }
+]
+
+const statusLabel = computed(() => props.task?.is_active ? '開啟' : '已關閉')
+
+const formattedCreationDate = computed(() => {
+  if (!props.task?.date_creation) return '-'
+  return new Date(props.task.date_creation * 1000).toLocaleString('zh-TW')
+})
+
+const formattedModificationDate = computed(() => {
+  if (!props.task?.date_modification) return '-'
+  return new Date(props.task.date_modification * 1000).toLocaleString('zh-TW')
+})
+
+const formattedDueDate = computed(() => {
+  if (!props.task?.date_due) return null
+  return new Date(props.task.date_due * 1000).toLocaleDateString('zh-TW')
+})
+
+const currentColumn = computed(() => {
+  if (!props.task) return null
+  return props.columns.find(col => col.id === props.task?.column_id)
+})
+
+watch(() => props.isOpen, (open) => {
+  if (open && props.task) {
+    editTitle.value = props.task.title
+    editDescription.value = props.task.description || ''
+    isEditingTitle.value = false
+    isEditingDescription.value = false
+  }
+})
+
+const handleClose = () => {
+  if (!isUpdating.value) {
+    emit('close')
+  }
+}
+
+const startEditTitle = () => {
+  if (props.task) {
+    editTitle.value = props.task.title
+    isEditingTitle.value = true
+  }
+}
+
+const cancelEditTitle = () => {
+  isEditingTitle.value = false
+  if (props.task) {
+    editTitle.value = props.task.title
+  }
+}
+
+const saveTitle = async () => {
+  if (!props.task || !editTitle.value.trim()) return
+
+  isUpdating.value = true
+  try {
+    await tasksStore.updateTask(props.task.id, { title: editTitle.value.trim() })
+    isEditingTitle.value = false
+    emit('updated')
+  } catch (error) {
+    console.error('Failed to update title:', error)
+    alert('更新標題失敗')
+  } finally {
+    isUpdating.value = false
+  }
+}
+
+const startEditDescription = () => {
+  if (props.task) {
+    editDescription.value = props.task.description || ''
+    isEditingDescription.value = true
+  }
+}
+
+const cancelEditDescription = () => {
+  isEditingDescription.value = false
+  if (props.task) {
+    editDescription.value = props.task.description || ''
+  }
+}
+
+const saveDescription = async () => {
+  if (!props.task) return
+
+  isUpdating.value = true
+  try {
+    await tasksStore.updateTask(props.task.id, { description: editDescription.value })
+    isEditingDescription.value = false
+    emit('updated')
+  } catch (error) {
+    console.error('Failed to update description:', error)
+    alert('更新描述失敗')
+  } finally {
+    isUpdating.value = false
+  }
+}
+
+const updateColor = async (colorId: string) => {
+  if (!props.task || props.task.color_id === colorId) return
+
+  isUpdating.value = true
+  try {
+    await tasksStore.updateTask(props.task.id, { color_id: colorId })
+    emit('updated')
+  } catch (error) {
+    console.error('Failed to update color:', error)
+    alert('更新顏色失敗')
+  } finally {
+    isUpdating.value = false
+  }
+}
+
+const closeTask = async () => {
+  if (!props.task) return
+
+  isUpdating.value = true
+  try {
+    await tasksStore.closeTask(props.task.id)
+    emit('updated')
+  } catch (error) {
+    console.error('Failed to close task:', error)
+    alert('關閉任務失敗')
+  } finally {
+    isUpdating.value = false
+  }
+}
+
+const openTask = async () => {
+  if (!props.task) return
+
+  isUpdating.value = true
+  try {
+    await tasksStore.openTask(props.task.id)
+    emit('updated')
+  } catch (error) {
+    console.error('Failed to open task:', error)
+    alert('重新開啟任務失敗')
+  } finally {
+    isUpdating.value = false
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="isOpen && task"
+      data-testid="task-detail-modal"
+      class="fixed inset-0 z-50 overflow-y-auto"
+    >
+      <!-- Backdrop -->
+      <div
+        class="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+        @click="handleClose"
+      ></div>
+
+      <!-- Modal -->
+      <div class="flex min-h-full items-center justify-center p-4">
+        <div
+          class="relative bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col"
+          @click.stop
+        >
+          <!-- Header -->
+          <div class="flex items-start justify-between p-4 border-b">
+            <div class="flex-1 min-w-0">
+              <!-- Task ID -->
+              <div class="text-sm text-gray-500 mb-1">#{{ task.id }}</div>
+
+              <!-- Title -->
+              <div v-if="!isEditingTitle" class="flex items-center gap-2">
+                <h2 class="text-xl font-semibold text-gray-900 truncate">{{ task.title }}</h2>
+                <button
+                  data-testid="edit-title-btn"
+                  @click="startEditTitle"
+                  class="text-gray-400 hover:text-gray-600"
+                  title="編輯標題"
+                >
+                  <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                  </svg>
+                </button>
+              </div>
+              <div v-else class="flex items-center gap-2">
+                <input
+                  data-testid="title-input"
+                  v-model="editTitle"
+                  type="text"
+                  class="flex-1 px-2 py-1 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  @keyup.enter="saveTitle"
+                  @keyup.escape="cancelEditTitle"
+                />
+                <button
+                  data-testid="save-title-btn"
+                  @click="saveTitle"
+                  :disabled="isUpdating"
+                  class="text-green-600 hover:text-green-800"
+                >
+                  <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                  </svg>
+                </button>
+                <button
+                  @click="cancelEditTitle"
+                  class="text-gray-400 hover:text-gray-600"
+                >
+                  <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            <!-- Close button -->
+            <button
+              data-testid="close-modal-btn"
+              @click="handleClose"
+              class="text-gray-400 hover:text-gray-500 ml-4"
+              :disabled="isUpdating"
+            >
+              <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Content -->
+          <div class="flex-1 overflow-y-auto p-4">
+            <div class="grid grid-cols-3 gap-6">
+              <!-- Main content (left side) -->
+              <div class="col-span-2 space-y-6">
+                <!-- Description -->
+                <div>
+                  <div class="flex items-center justify-between mb-2">
+                    <h3 class="text-sm font-medium text-gray-700">描述</h3>
+                    <button
+                      v-if="!isEditingDescription"
+                      @click="startEditDescription"
+                      class="text-gray-400 hover:text-gray-600 text-sm"
+                    >
+                      編輯
+                    </button>
+                  </div>
+                  <div v-if="!isEditingDescription">
+                    <p v-if="task.description" class="text-gray-600 whitespace-pre-wrap">{{ task.description }}</p>
+                    <p v-else class="text-gray-400 italic">無描述</p>
+                  </div>
+                  <div v-else class="space-y-2">
+                    <textarea
+                      v-model="editDescription"
+                      rows="4"
+                      class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      placeholder="輸入任務描述..."
+                    ></textarea>
+                    <div class="flex gap-2">
+                      <button
+                        @click="saveDescription"
+                        :disabled="isUpdating"
+                        class="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                      >
+                        儲存
+                      </button>
+                      <button
+                        @click="cancelEditDescription"
+                        class="px-3 py-1 text-sm bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
+                      >
+                        取消
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Sidebar (right side) -->
+              <div class="space-y-4">
+                <!-- Status -->
+                <div>
+                  <h3 class="text-sm font-medium text-gray-700 mb-2">狀態</h3>
+                  <div class="flex items-center gap-2">
+                    <span
+                      :class="[
+                        'px-2 py-1 text-xs font-medium rounded',
+                        task.is_active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'
+                      ]"
+                    >
+                      {{ statusLabel }}
+                    </span>
+                    <button
+                      v-if="task.is_active"
+                      data-testid="close-task-btn"
+                      @click="closeTask"
+                      :disabled="isUpdating"
+                      class="text-xs text-gray-500 hover:text-gray-700"
+                    >
+                      關閉任務
+                    </button>
+                    <button
+                      v-else
+                      data-testid="open-task-btn"
+                      @click="openTask"
+                      :disabled="isUpdating"
+                      class="text-xs text-blue-500 hover:text-blue-700"
+                    >
+                      重新開啟
+                    </button>
+                  </div>
+                </div>
+
+                <!-- Column -->
+                <div>
+                  <h3 class="text-sm font-medium text-gray-700 mb-2">欄位</h3>
+                  <span class="text-sm text-gray-600">{{ currentColumn?.title || '-' }}</span>
+                </div>
+
+                <!-- Color -->
+                <div data-testid="color-selector">
+                  <h3 class="text-sm font-medium text-gray-700 mb-2">顏色</h3>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      v-for="color in colors"
+                      :key="color.id"
+                      :data-testid="`color-${color.id}`"
+                      @click="updateColor(color.id)"
+                      :disabled="isUpdating"
+                      :class="[
+                        'w-6 h-6 rounded-full transition-transform',
+                        color.class,
+                        task.color_id === color.id ? 'ring-2 ring-offset-1 ring-gray-400 scale-110' : 'hover:scale-105'
+                      ]"
+                      :title="color.name"
+                    ></button>
+                  </div>
+                </div>
+
+                <!-- Due Date -->
+                <div data-testid="due-date" v-if="formattedDueDate">
+                  <h3 class="text-sm font-medium text-gray-700 mb-2">到期日</h3>
+                  <span class="text-sm text-gray-600">{{ formattedDueDate }}</span>
+                </div>
+
+                <!-- Priority -->
+                <div v-if="task.priority">
+                  <h3 class="text-sm font-medium text-gray-700 mb-2">優先級</h3>
+                  <span class="text-sm text-gray-600">{{ task.priority }}</span>
+                </div>
+
+                <!-- Dates -->
+                <div class="pt-4 border-t space-y-2">
+                  <div>
+                    <span class="text-xs text-gray-500">建立於</span>
+                    <span class="text-xs text-gray-600 ml-1">{{ formattedCreationDate }}</span>
+                  </div>
+                  <div>
+                    <span class="text-xs text-gray-500">更新於</span>
+                    <span class="text-xs text-gray-600 ml-1">{{ formattedModificationDate }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -6,6 +6,7 @@ import { useBoardStore } from '@/stores/board'
 import { useTasksStore } from '@/stores/tasks'
 import TaskCard from '@/components/TaskCard.vue'
 import TaskFormModal from '@/components/TaskFormModal.vue'
+import TaskDetailModal from '@/components/TaskDetailModal.vue'
 import type { Task } from '@/types'
 
 const route = useRoute()
@@ -20,6 +21,10 @@ const projectId = Number(route.params.id)
 const showTaskModal = ref(false)
 const defaultColumnId = ref<number>(0)
 const taskModalRef = ref<InstanceType<typeof TaskFormModal> | null>(null)
+
+// Task detail modal state
+const showTaskDetailModal = ref(false)
+const selectedTask = ref<Task | null>(null)
 
 onMounted(() => {
   boardStore.fetchBoard(projectId)
@@ -41,8 +46,13 @@ const goToProjects = () => {
 }
 
 const handleTaskClick = (task: Task) => {
-  console.log('Task clicked:', task.id)
-  // TODO: Open task detail modal
+  selectedTask.value = task
+  showTaskDetailModal.value = true
+}
+
+const handleTaskUpdated = async () => {
+  // Refresh board to get updated task data
+  await boardStore.fetchBoard(projectId)
 }
 
 const openAddTaskModal = (columnId: number) => {
@@ -187,6 +197,16 @@ const handleCreateTask = async (data: {
       :default-column-id="defaultColumnId"
       @close="showTaskModal = false"
       @submit="handleCreateTask"
+    />
+
+    <!-- Task Detail Modal -->
+    <TaskDetailModal
+      :is-open="showTaskDetailModal"
+      :task="selectedTask"
+      :columns="boardStore.columns"
+      :project-id="projectId"
+      @close="showTaskDetailModal = false"
+      @updated="handleTaskUpdated"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary

- 建立 TaskDetailModal 元件，顯示任務完整資訊
- 支援編輯標題和描述
- 支援變更任務顏色
- 支援關閉/重新開啟任務
- 顯示建立時間、更新時間、到期日等資訊
- 整合至 BoardView，點擊任務卡片開啟詳情

## Files Changed

- `src/components/TaskDetailModal.vue` - 任務詳情 Modal 元件
- `src/__tests__/TaskDetailModal.test.ts` - 任務詳情 Modal 測試（16 項）
- `src/views/BoardView.vue` - 整合任務詳情 Modal

## Features

### 基本資訊區
- 任務 ID 顯示
- 任務標題（可編輯）
- 任務描述（可編輯）
- 狀態顯示（開啟/已關閉）

### 屬性區
- 欄位顯示
- 顏色選擇（16 種顏色）
- 到期日顯示
- 優先級顯示
- 建立時間/更新時間

### 操作
- 關閉任務
- 重新開啟任務

## Test Plan

- [x] 所有單元測試通過（79 項）
- [x] TypeScript 類型檢查通過
- [ ] 手動測試：點擊任務卡片開啟詳情 Modal
- [ ] 手動測試：編輯標題並儲存
- [ ] 手動測試：編輯描述並儲存
- [ ] 手動測試：變更顏色
- [ ] 手動測試：關閉/重新開啟任務

Closes #13