### PR TITLE
feat(admin): 新增管理員使用者管理功能

### DIFF
--- a/src/__tests__/users-store.test.ts
+++ b/src/__tests__/users-store.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useUsersStore } from '@/stores/users'
+import { useAuthStore } from '@/stores/auth'
+import type { User } from '@/types'
+
+const mockFetch = vi.fn()
+
+const mockUsers: User[] = [
+  {
+    id: 1,
+    username: 'admin',
+    name: 'Administrator',
+    email: 'admin@example.com',
+    role: 'app-admin',
+    is_active: true
+  },
+  {
+    id: 2,
+    username: 'user1',
+    name: 'User One',
+    email: 'user1@example.com',
+    role: 'app-user',
+    is_active: true
+  },
+  {
+    id: 3,
+    username: 'user2',
+    name: 'User Two',
+    email: 'user2@example.com',
+    role: 'app-user',
+    is_active: false
+  }
+]
+
+describe('Users Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.stubGlobal('fetch', mockFetch)
+    mockFetch.mockReset()
+
+    // Setup auth store with credentials
+    const authStore = useAuthStore()
+    authStore.apiUrl = 'http://localhost/jsonrpc.php'
+    authStore.username = 'admin'
+    authStore.token = 'admin'
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('initial state', () => {
+    it('should have empty users', () => {
+      const store = useUsersStore()
+
+      expect(store.users).toEqual([])
+      expect(store.isLoading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+  })
+
+  describe('fetchAllUsers', () => {
+    it('should fetch and store users', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockUsers
+        })
+      })
+
+      const store = useUsersStore()
+      await store.fetchAllUsers()
+
+      expect(store.users).toEqual(mockUsers)
+      expect(store.isLoading).toBe(false)
+    })
+
+    it('should handle fetch error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const store = useUsersStore()
+      await store.fetchAllUsers()
+
+      expect(store.users).toEqual([])
+      expect(store.error).toBe('Network error')
+    })
+
+    it('should call API with correct method', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockUsers
+        })
+      })
+
+      const store = useUsersStore()
+      await store.fetchAllUsers()
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(callBody.method).toBe('getAllUsers')
+    })
+  })
+
+  describe('getUser', () => {
+    it('should get single user', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockUsers[0]
+        })
+      })
+
+      const store = useUsersStore()
+      const user = await store.getUser(1)
+
+      expect(user).toEqual(mockUsers[0])
+    })
+
+    it('should call API with correct parameters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockUsers[0]
+        })
+      })
+
+      const store = useUsersStore()
+      await store.getUser(5)
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(callBody.method).toBe('getUser')
+      expect(callBody.params).toEqual({ user_id: 5 })
+    })
+  })
+
+  describe('createUser', () => {
+    it('should create user and return id', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: 10
+        })
+      })
+
+      const store = useUsersStore()
+      const result = await store.createUser({
+        username: 'newuser',
+        password: 'password123',
+        name: 'New User',
+        email: 'new@example.com',
+        role: 'app-user'
+      })
+
+      expect(result).toBe(10)
+    })
+
+    it('should call API with correct parameters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: 5
+        })
+      })
+
+      const store = useUsersStore()
+      await store.createUser({
+        username: 'testuser',
+        password: 'test123',
+        name: 'Test User',
+        email: 'test@example.com',
+        role: 'app-manager'
+      })
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(callBody.method).toBe('createUser')
+      expect(callBody.params).toEqual({
+        username: 'testuser',
+        password: 'test123',
+        name: 'Test User',
+        email: 'test@example.com',
+        role: 'app-manager'
+      })
+    })
+  })
+
+  describe('updateUser', () => {
+    it('should update user and return true', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useUsersStore()
+      const result = await store.updateUser(1, { name: 'Updated Name' })
+
+      expect(result).toBe(true)
+    })
+
+    it('should call API with correct parameters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useUsersStore()
+      await store.updateUser(5, {
+        name: 'Updated Name',
+        email: 'updated@example.com',
+        role: 'app-admin'
+      })
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(callBody.method).toBe('updateUser')
+      expect(callBody.params).toEqual({
+        id: 5,
+        name: 'Updated Name',
+        email: 'updated@example.com',
+        role: 'app-admin'
+      })
+    })
+  })
+
+  describe('enableUser', () => {
+    it('should enable user and return true', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useUsersStore()
+      const result = await store.enableUser(3)
+
+      expect(result).toBe(true)
+    })
+
+    it('should call API with correct parameters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useUsersStore()
+      await store.enableUser(5)
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(callBody.method).toBe('enableUser')
+      expect(callBody.params).toEqual({ user_id: 5 })
+    })
+  })
+
+  describe('disableUser', () => {
+    it('should disable user and return true', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useUsersStore()
+      const result = await store.disableUser(2)
+
+      expect(result).toBe(true)
+    })
+
+    it('should call API with correct parameters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useUsersStore()
+      await store.disableUser(5)
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(callBody.method).toBe('disableUser')
+      expect(callBody.params).toEqual({ user_id: 5 })
+    })
+  })
+
+  describe('removeUser', () => {
+    it('should remove user and return true', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useUsersStore()
+      const result = await store.removeUser(2)
+
+      expect(result).toBe(true)
+    })
+
+    it('should call API with correct parameters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: true
+        })
+      })
+
+      const store = useUsersStore()
+      await store.removeUser(5)
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(callBody.method).toBe('removeUser')
+      expect(callBody.params).toEqual({ user_id: 5 })
+    })
+  })
+
+  describe('computed properties', () => {
+    it('should return users count', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockUsers
+        })
+      })
+
+      const store = useUsersStore()
+      await store.fetchAllUsers()
+
+      expect(store.usersCount).toBe(3)
+    })
+
+    it('should return active users', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockUsers
+        })
+      })
+
+      const store = useUsersStore()
+      await store.fetchAllUsers()
+
+      expect(store.activeUsers.length).toBe(2)
+      expect(store.activeUsers.every(u => u.is_active)).toBe(true)
+    })
+  })
+
+  describe('clearUsers', () => {
+    it('should clear all users', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockUsers
+        })
+      })
+
+      const store = useUsersStore()
+      await store.fetchAllUsers()
+      expect(store.users.length).toBe(3)
+
+      store.clearUsers()
+
+      expect(store.users).toEqual([])
+      expect(store.error).toBeNull()
+    })
+  })
+})

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -47,6 +47,12 @@ const router = createRouter({
       meta: { requiresAuth: true }
     },
     {
+      path: '/admin/users',
+      name: 'admin-users',
+      component: () => import('@/views/UsersManagementView.vue'),
+      meta: { requiresAuth: true }
+    },
+    {
       path: '/login',
       name: 'login',
       component: () => import('@/views/LoginView.vue'),

--- a/src/stores/users.ts
+++ b/src/stores/users.ts
@@ -1,0 +1,129 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useAuthStore } from './auth'
+import type { User } from '@/types'
+
+interface CreateUserParams {
+  username: string
+  password: string
+  name?: string
+  email?: string
+  role?: string
+}
+
+interface UpdateUserParams {
+  name?: string
+  email?: string
+  role?: string
+}
+
+export const useUsersStore = defineStore('users', () => {
+  const users = ref<User[]>([])
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  // Computed properties
+  const usersCount = computed(() => users.value.length)
+
+  const activeUsers = computed(() => {
+    return users.value.filter(u => u.is_active)
+  })
+
+  async function fetchAllUsers(): Promise<void> {
+    const authStore = useAuthStore()
+
+    isLoading.value = true
+    error.value = null
+
+    try {
+      const client = authStore.getClient()
+      const result = await client.call<User[]>('getAllUsers')
+      users.value = result || []
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : '載入使用者失敗'
+      users.value = []
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function getUser(userId: number): Promise<User | null> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<User | null>('getUser', {
+      user_id: userId
+    })
+    return result
+  }
+
+  async function createUser(params: CreateUserParams): Promise<number> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<number>('createUser', params)
+    return result
+  }
+
+  async function updateUser(userId: number, params: UpdateUserParams): Promise<boolean> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<boolean>('updateUser', {
+      id: userId,
+      ...params
+    })
+    return result
+  }
+
+  async function enableUser(userId: number): Promise<boolean> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<boolean>('enableUser', {
+      user_id: userId
+    })
+    return result
+  }
+
+  async function disableUser(userId: number): Promise<boolean> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<boolean>('disableUser', {
+      user_id: userId
+    })
+    return result
+  }
+
+  async function removeUser(userId: number): Promise<boolean> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<boolean>('removeUser', {
+      user_id: userId
+    })
+    return result
+  }
+
+  function clearUsers(): void {
+    users.value = []
+    error.value = null
+  }
+
+  return {
+    users,
+    isLoading,
+    error,
+    usersCount,
+    activeUsers,
+    fetchAllUsers,
+    getUser,
+    createUser,
+    updateUser,
+    enableUser,
+    disableUser,
+    removeUser,
+    clearUsers
+  }
+})

--- a/src/views/UsersManagementView.vue
+++ b/src/views/UsersManagementView.vue
@@ -1,0 +1,462 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { useUsersStore } from '@/stores/users'
+import NotificationsDropdown from '@/components/NotificationsDropdown.vue'
+import type { User } from '@/types'
+
+const router = useRouter()
+const authStore = useAuthStore()
+const usersStore = useUsersStore()
+
+// Form state
+const isAdding = ref(false)
+const isSubmitting = ref(false)
+const error = ref<string | null>(null)
+const successMessage = ref<string | null>(null)
+
+// New user form
+const newUsername = ref('')
+const newPassword = ref('')
+const newName = ref('')
+const newEmail = ref('')
+const newRole = ref('app-user')
+
+// Edit state
+const editingUserId = ref<number | null>(null)
+const editName = ref('')
+const editEmail = ref('')
+const editRole = ref('')
+
+const roles = [
+  { value: 'app-admin', label: '系統管理員' },
+  { value: 'app-manager', label: '專案經理' },
+  { value: 'app-user', label: '一般使用者' }
+]
+
+const getRoleLabel = (role: string) => {
+  return roles.find(r => r.value === role)?.label || role
+}
+
+onMounted(async () => {
+  await usersStore.fetchAllUsers()
+})
+
+const startAdding = () => {
+  isAdding.value = true
+  newUsername.value = ''
+  newPassword.value = ''
+  newName.value = ''
+  newEmail.value = ''
+  newRole.value = 'app-user'
+  error.value = null
+}
+
+const cancelAdding = () => {
+  isAdding.value = false
+}
+
+const handleAddUser = async () => {
+  if (!newUsername.value.trim() || !newPassword.value || isSubmitting.value) return
+
+  isSubmitting.value = true
+  error.value = null
+
+  try {
+    await usersStore.createUser({
+      username: newUsername.value.trim(),
+      password: newPassword.value,
+      name: newName.value.trim() || undefined,
+      email: newEmail.value.trim() || undefined,
+      role: newRole.value
+    })
+    await usersStore.fetchAllUsers()
+    cancelAdding()
+    successMessage.value = '使用者新增成功'
+    setTimeout(() => {
+      successMessage.value = null
+    }, 3000)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : '新增使用者失敗'
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+const startEditing = (user: User) => {
+  editingUserId.value = user.id
+  editName.value = user.name || ''
+  editEmail.value = user.email || ''
+  editRole.value = user.role
+  error.value = null
+}
+
+const cancelEditing = () => {
+  editingUserId.value = null
+}
+
+const handleSaveUser = async () => {
+  if (!editingUserId.value || isSubmitting.value) return
+
+  isSubmitting.value = true
+  error.value = null
+
+  try {
+    await usersStore.updateUser(editingUserId.value, {
+      name: editName.value.trim() || undefined,
+      email: editEmail.value.trim() || undefined,
+      role: editRole.value
+    })
+    await usersStore.fetchAllUsers()
+    cancelEditing()
+    successMessage.value = '使用者更新成功'
+    setTimeout(() => {
+      successMessage.value = null
+    }, 3000)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : '更新使用者失敗'
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+const handleToggleActive = async (user: User) => {
+  try {
+    if (user.is_active) {
+      await usersStore.disableUser(user.id)
+    } else {
+      await usersStore.enableUser(user.id)
+    }
+    await usersStore.fetchAllUsers()
+    successMessage.value = `使用者已${user.is_active ? '停用' : '啟用'}`
+    setTimeout(() => {
+      successMessage.value = null
+    }, 3000)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : '切換狀態失敗'
+  }
+}
+
+const handleRemoveUser = async (user: User) => {
+  if (!confirm(`確定要刪除使用者「${user.username}」嗎？此操作無法復原。`)) return
+
+  try {
+    await usersStore.removeUser(user.id)
+    await usersStore.fetchAllUsers()
+    successMessage.value = '使用者已刪除'
+    setTimeout(() => {
+      successMessage.value = null
+    }, 3000)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : '刪除使用者失敗'
+  }
+}
+
+const goBack = () => {
+  router.back()
+}
+
+const handleLogout = () => {
+  authStore.logout()
+  router.push('/login')
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-100">
+    <!-- Header -->
+    <header class="bg-white shadow">
+      <div class="mx-auto max-w-7xl px-4 py-4 flex justify-between items-center">
+        <div class="flex items-center gap-4">
+          <button
+            @click="goBack"
+            class="text-gray-600 hover:text-gray-900"
+          >
+            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <h1 class="text-xl font-bold text-gray-900">使用者管理</h1>
+        </div>
+        <div class="flex items-center gap-4">
+          <NotificationsDropdown />
+          <span class="text-gray-600 text-sm">
+            {{ authStore.user?.name || authStore.user?.username }}
+          </span>
+          <button
+            @click="handleLogout"
+            class="px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+          >
+            登出
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <main class="mx-auto max-w-4xl px-4 py-6">
+      <!-- Error Alert -->
+      <div v-if="error" class="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
+        <div class="flex items-center gap-2 text-red-800">
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <span>{{ error }}</span>
+        </div>
+      </div>
+
+      <!-- Success Alert -->
+      <div v-if="successMessage" class="mb-6 bg-green-50 border border-green-200 rounded-lg p-4">
+        <div class="flex items-center gap-2 text-green-800">
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+          <span>{{ successMessage }}</span>
+        </div>
+      </div>
+
+      <!-- Header with Add button -->
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="text-lg font-semibold text-gray-900">
+          所有使用者
+          <span v-if="usersStore.usersCount > 0" class="text-gray-400 text-sm font-normal">
+            ({{ usersStore.usersCount }})
+          </span>
+        </h2>
+        <button
+          v-if="!isAdding"
+          @click="startAdding"
+          class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+        >
+          + 新增使用者
+        </button>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="usersStore.isLoading" class="flex items-center justify-center py-12">
+        <svg class="animate-spin h-8 w-8 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+      </div>
+
+      <div v-else class="space-y-4">
+        <!-- Add user form -->
+        <div v-if="isAdding" class="bg-white rounded-lg shadow p-6 space-y-4">
+          <h3 class="text-lg font-semibold text-gray-900">新增使用者</h3>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">使用者名稱 *</label>
+              <input
+                v-model="newUsername"
+                type="text"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="輸入使用者名稱"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">密碼 *</label>
+              <input
+                v-model="newPassword"
+                type="password"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="輸入密碼"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">顯示名稱</label>
+              <input
+                v-model="newName"
+                type="text"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="選填"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">電子郵件</label>
+              <input
+                v-model="newEmail"
+                type="email"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="選填"
+              />
+            </div>
+            <div class="col-span-2">
+              <label class="block text-sm font-medium text-gray-700 mb-1">角色</label>
+              <select
+                v-model="newRole"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option v-for="role in roles" :key="role.value" :value="role.value">
+                  {{ role.label }}
+                </option>
+              </select>
+            </div>
+          </div>
+
+          <div class="flex gap-2 justify-end">
+            <button
+              @click="cancelAdding"
+              :disabled="isSubmitting"
+              class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200"
+            >
+              取消
+            </button>
+            <button
+              @click="handleAddUser"
+              :disabled="!newUsername.trim() || !newPassword || isSubmitting"
+              class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+            >
+              新增
+            </button>
+          </div>
+        </div>
+
+        <!-- Users list -->
+        <div class="bg-white rounded-lg shadow">
+          <div class="divide-y">
+            <div
+              v-for="user in usersStore.users"
+              :key="user.id"
+              class="p-4"
+            >
+              <!-- View mode -->
+              <div v-if="editingUserId !== user.id" class="flex items-center justify-between">
+                <div class="flex items-center gap-4">
+                  <!-- Avatar -->
+                  <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center">
+                    <span class="text-gray-600 font-medium">
+                      {{ (user.name || user.username).charAt(0).toUpperCase() }}
+                    </span>
+                  </div>
+
+                  <!-- User info -->
+                  <div>
+                    <div class="flex items-center gap-2">
+                      <span class="font-medium text-gray-900">{{ user.name || user.username }}</span>
+                      <span
+                        v-if="!user.is_active"
+                        class="text-xs px-2 py-0.5 bg-red-100 text-red-700 rounded"
+                      >
+                        已停用
+                      </span>
+                      <span
+                        v-if="user.role === 'app-admin'"
+                        class="text-xs px-2 py-0.5 bg-purple-100 text-purple-700 rounded"
+                      >
+                        管理員
+                      </span>
+                    </div>
+                    <div class="text-sm text-gray-500">
+                      @{{ user.username }}
+                      <span v-if="user.email">· {{ user.email }}</span>
+                    </div>
+                    <div class="text-xs text-gray-400">
+                      {{ getRoleLabel(user.role) }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-2">
+                  <!-- Toggle active -->
+                  <button
+                    @click="handleToggleActive(user)"
+                    :disabled="user.id === authStore.user?.id"
+                    class="p-2 text-gray-400 hover:text-gray-600 disabled:opacity-30"
+                    :title="user.is_active ? '停用' : '啟用'"
+                  >
+                    <svg v-if="user.is_active" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                    </svg>
+                    <svg v-else class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                  </button>
+                  <!-- Edit -->
+                  <button
+                    @click="startEditing(user)"
+                    class="p-2 text-gray-400 hover:text-gray-600"
+                    title="編輯"
+                  >
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                    </svg>
+                  </button>
+                  <!-- Delete -->
+                  <button
+                    @click="handleRemoveUser(user)"
+                    :disabled="user.id === authStore.user?.id"
+                    class="p-2 text-gray-400 hover:text-red-500 disabled:opacity-30"
+                    title="刪除"
+                  >
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+
+              <!-- Edit mode -->
+              <div v-else class="space-y-4">
+                <div class="grid grid-cols-2 gap-4">
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">顯示名稱</label>
+                    <input
+                      v-model="editName"
+                      type="text"
+                      class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">電子郵件</label>
+                    <input
+                      v-model="editEmail"
+                      type="email"
+                      class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                  <div class="col-span-2">
+                    <label class="block text-sm font-medium text-gray-700 mb-1">角色</label>
+                    <select
+                      v-model="editRole"
+                      class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      <option v-for="role in roles" :key="role.value" :value="role.value">
+                        {{ role.label }}
+                      </option>
+                    </select>
+                  </div>
+                </div>
+                <div class="flex gap-2 justify-end">
+                  <button
+                    @click="cancelEditing"
+                    :disabled="isSubmitting"
+                    class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200"
+                  >
+                    取消
+                  </button>
+                  <button
+                    @click="handleSaveUser"
+                    :disabled="isSubmitting"
+                    class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    儲存
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Empty state -->
+            <div
+              v-if="usersStore.users.length === 0 && !usersStore.isLoading"
+              class="p-8 text-center text-gray-500"
+            >
+              沒有使用者
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

- 新增 users store (`src/stores/users.ts`) 包含所有使用者管理 API 操作
- 新增 UsersManagementView 頁面 (`src/views/UsersManagementView.vue`)
- 新增 `/admin/users` 路由

## 功能

- 取得所有使用者列表
- 新增使用者（帳號、密碼、名稱、Email、角色）
- 編輯使用者（名稱、Email、角色）
- 啟用/停用使用者
- 刪除使用者

## API 支援

| API | 說明 |
|-----|------|
| `getAllUsers` | 取得所有使用者 |
| `getUser` | 取得單一使用者 |
| `createUser` | 新增使用者 |
| `updateUser` | 更新使用者 |
| `enableUser` | 啟用使用者 |
| `disableUser` | 停用使用者 |
| `removeUser` | 刪除使用者 |

## Test plan

- [x] 19 個單元測試全數通過
- [x] 全部 278 個測試通過

Closes #47