### PR TITLE
feat(shortcuts): 新增鍵盤快捷鍵系統

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,69 @@
 <script setup lang="ts">
-import { RouterView } from 'vue-router'
+import { ref, onMounted, onUnmounted, provide } from 'vue'
+import { RouterView, useRouter } from 'vue-router'
+import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
+import KeyboardShortcutsModal from '@/components/KeyboardShortcutsModal.vue'
+import SearchModal from '@/components/SearchModal.vue'
+
+const router = useRouter()
+const shortcuts = useKeyboardShortcuts()
+const showShortcutsModal = ref(false)
+const showSearchModal = ref(false)
+
+// Provide shortcuts to child components
+provide('shortcuts', shortcuts)
+
+let cleanup: (() => void) | null = null
+
+onMounted(() => {
+  cleanup = shortcuts.init()
+
+  // Global shortcuts
+  shortcuts.register('?', () => {
+    showShortcutsModal.value = true
+  }, { description: '顯示快捷鍵說明' })
+
+  shortcuts.register('k', () => {
+    showSearchModal.value = true
+  }, { ctrl: true, description: '開啟快速搜尋' })
+
+  shortcuts.register('k', () => {
+    showSearchModal.value = true
+  }, { meta: true, description: '開啟快速搜尋' })
+
+  shortcuts.register('Escape', () => {
+    showShortcutsModal.value = false
+    showSearchModal.value = false
+  }, { description: '關閉對話框' })
+
+  shortcuts.register('b', () => {
+    router.push('/')
+  }, { description: '開啟專案列表' })
+})
+
+onUnmounted(() => {
+  if (cleanup) {
+    cleanup()
+  }
+})
+
+function handleSearchSelect(taskId: number, projectId: number) {
+  showSearchModal.value = false
+  router.push(`/projects/${projectId}`)
+}
 </script>
 
 <template>
   <RouterView />
+
+  <KeyboardShortcutsModal
+    :is-open="showShortcutsModal"
+    @close="showShortcutsModal = false"
+  />
+
+  <SearchModal
+    :is-open="showSearchModal"
+    @close="showSearchModal = false"
+    @select="handleSearchSelect"
+  />
 </template>

--- a/src/__tests__/keyboard-shortcuts.test.ts
+++ b/src/__tests__/keyboard-shortcuts.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
+
+describe('useKeyboardShortcuts', () => {
+  let shortcuts: ReturnType<typeof useKeyboardShortcuts>
+  let cleanup: () => void
+
+  beforeEach(() => {
+    shortcuts = useKeyboardShortcuts()
+    cleanup = shortcuts.init()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  function dispatchKeyEvent(key: string, options: Partial<KeyboardEventInit> = {}) {
+    const event = new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      ...options
+    })
+    document.dispatchEvent(event)
+    return event
+  }
+
+  describe('init', () => {
+    it('should return cleanup function', () => {
+      expect(typeof cleanup).toBe('function')
+    })
+  })
+
+  describe('register', () => {
+    it('should register a shortcut', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler)
+
+      dispatchKeyEvent('k')
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should register shortcut with ctrl modifier', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler, { ctrl: true })
+
+      dispatchKeyEvent('k', { ctrlKey: true })
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should register shortcut with meta modifier', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler, { meta: true })
+
+      dispatchKeyEvent('k', { metaKey: true })
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should register shortcut with shift modifier', () => {
+      const handler = vi.fn()
+      shortcuts.register('K', handler, { shift: true })
+
+      dispatchKeyEvent('K', { shiftKey: true })
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not trigger without required modifier', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler, { ctrl: true })
+
+      dispatchKeyEvent('k')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should return unregister function', () => {
+      const handler = vi.fn()
+      const unregister = shortcuts.register('k', handler)
+
+      unregister()
+      dispatchKeyEvent('k')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unregister', () => {
+    it('should unregister a shortcut', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler)
+
+      shortcuts.unregister('k')
+      dispatchKeyEvent('k')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should unregister shortcut with modifiers', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler, { ctrl: true })
+
+      shortcuts.unregister('k', { ctrl: true })
+      dispatchKeyEvent('k', { ctrlKey: true })
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isInputFocused', () => {
+    it('should not trigger when input is focused', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler)
+
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      dispatchKeyEvent('k')
+
+      expect(handler).not.toHaveBeenCalled()
+
+      document.body.removeChild(input)
+    })
+
+    it('should not trigger when textarea is focused', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler)
+
+      const textarea = document.createElement('textarea')
+      document.body.appendChild(textarea)
+      textarea.focus()
+
+      dispatchKeyEvent('k')
+
+      expect(handler).not.toHaveBeenCalled()
+
+      document.body.removeChild(textarea)
+    })
+
+    it('should trigger when contenteditable is not focused', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler)
+
+      dispatchKeyEvent('k')
+
+      expect(handler).toHaveBeenCalled()
+    })
+  })
+
+  describe('multiple shortcuts', () => {
+    it('should support multiple shortcuts', () => {
+      const handler1 = vi.fn()
+      const handler2 = vi.fn()
+
+      shortcuts.register('a', handler1)
+      shortcuts.register('b', handler2)
+
+      dispatchKeyEvent('a')
+      dispatchKeyEvent('b')
+
+      expect(handler1).toHaveBeenCalledTimes(1)
+      expect(handler2).toHaveBeenCalledTimes(1)
+    })
+
+    it('should override existing shortcut', () => {
+      const handler1 = vi.fn()
+      const handler2 = vi.fn()
+
+      shortcuts.register('k', handler1)
+      shortcuts.register('k', handler2)
+
+      dispatchKeyEvent('k')
+
+      expect(handler1).not.toHaveBeenCalled()
+      expect(handler2).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('getShortcuts', () => {
+    it('should return registered shortcuts', () => {
+      shortcuts.register('k', vi.fn(), { description: 'Open search' })
+      shortcuts.register('n', vi.fn(), { description: 'New task' })
+
+      const registered = shortcuts.getShortcuts()
+
+      expect(registered).toHaveLength(2)
+      expect(registered[0].description).toBe('Open search')
+      expect(registered[1].description).toBe('New task')
+    })
+  })
+
+  describe('setEnabled', () => {
+    it('should disable all shortcuts', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler)
+
+      shortcuts.setEnabled(false)
+      dispatchKeyEvent('k')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should re-enable shortcuts', () => {
+      const handler = vi.fn()
+      shortcuts.register('k', handler)
+
+      shortcuts.setEnabled(false)
+      shortcuts.setEnabled(true)
+      dispatchKeyEvent('k')
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/components/KeyboardShortcutsModal.vue
+++ b/src/components/KeyboardShortcutsModal.vue
@@ -1,0 +1,120 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div
+        v-if="isOpen"
+        class="fixed inset-0 z-50 overflow-y-auto"
+        @click.self="$emit('close')"
+      >
+        <div class="flex min-h-full items-center justify-center p-4">
+          <!-- Backdrop -->
+          <div class="fixed inset-0 bg-black/50" @click="$emit('close')"></div>
+
+          <!-- Modal -->
+          <div class="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-lg transform transition-all">
+            <!-- Header -->
+            <div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">鍵盤快捷鍵</h2>
+              <button
+                @click="$emit('close')"
+                class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            <!-- Content -->
+            <div class="p-4 max-h-96 overflow-y-auto">
+              <!-- Global Shortcuts -->
+              <section class="mb-6">
+                <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">全域</h3>
+                <div class="space-y-2">
+                  <ShortcutItem shortcut="Cmd/Ctrl + K" description="開啟快速搜尋" />
+                  <ShortcutItem shortcut="?" description="顯示快捷鍵說明" />
+                  <ShortcutItem shortcut="b" description="開啟專案切換器" />
+                  <ShortcutItem shortcut="Esc" description="關閉對話框" />
+                </div>
+              </section>
+
+              <!-- Board View Shortcuts -->
+              <section class="mb-6">
+                <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">看板檢視</h3>
+                <div class="space-y-2">
+                  <ShortcutItem shortcut="n" description="新增任務" />
+                  <ShortcutItem shortcut="v b" description="切換至看板" />
+                  <ShortcutItem shortcut="v l" description="切換至清單" />
+                  <ShortcutItem shortcut="v c" description="切換至日曆" />
+                  <ShortcutItem shortcut="v a" description="切換至分析" />
+                </div>
+              </section>
+
+              <!-- Task Detail Shortcuts -->
+              <section>
+                <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">任務詳情</h3>
+                <div class="space-y-2">
+                  <ShortcutItem shortcut="e" description="編輯任務" />
+                  <ShortcutItem shortcut="s" description="新增子任務" />
+                  <ShortcutItem shortcut="c" description="新增評論" />
+                </div>
+              </section>
+            </div>
+
+            <!-- Footer -->
+            <div class="px-4 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 rounded-b-lg">
+              <p class="text-xs text-gray-500 dark:text-gray-400 text-center">
+                按下 <kbd class="px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 rounded text-xs font-mono">?</kbd> 或 <kbd class="px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 rounded text-xs font-mono">Esc</kbd> 關閉
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  isOpen: boolean
+}>()
+
+defineEmits<{
+  close: []
+}>()
+
+// Internal component for shortcut items
+const ShortcutItem = {
+  props: ['shortcut', 'description'],
+  template: `
+    <div class="flex items-center justify-between py-1">
+      <span class="text-sm text-gray-700 dark:text-gray-300">{{ description }}</span>
+      <kbd class="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-xs font-mono text-gray-600 dark:text-gray-400">
+        {{ shortcut }}
+      </kbd>
+    </div>
+  `
+}
+</script>
+
+<style scoped>
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-active .relative,
+.modal-leave-active .relative {
+  transition: transform 0.2s ease;
+}
+
+.modal-enter-from .relative,
+.modal-leave-to .relative {
+  transform: scale(0.95);
+}
+</style>

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -1,0 +1,113 @@
+import { ref } from 'vue'
+
+export interface ShortcutOptions {
+  ctrl?: boolean
+  meta?: boolean
+  shift?: boolean
+  alt?: boolean
+  description?: string
+}
+
+export interface RegisteredShortcut {
+  key: string
+  handler: () => void
+  options: ShortcutOptions
+  description?: string
+}
+
+function getShortcutKey(key: string, options: ShortcutOptions = {}): string {
+  const parts: string[] = []
+  if (options.ctrl) parts.push('ctrl')
+  if (options.meta) parts.push('meta')
+  if (options.shift) parts.push('shift')
+  if (options.alt) parts.push('alt')
+  parts.push(key.toLowerCase())
+  return parts.join('+')
+}
+
+export function useKeyboardShortcuts() {
+  const shortcuts = ref<Map<string, RegisteredShortcut>>(new Map())
+  const enabled = ref(true)
+
+  function isInputFocused(): boolean {
+    const activeElement = document.activeElement
+    if (!activeElement) return false
+
+    const tagName = activeElement.tagName.toLowerCase()
+    if (tagName === 'input' || tagName === 'textarea') {
+      return true
+    }
+
+    if (activeElement.getAttribute('contenteditable') === 'true') {
+      return true
+    }
+
+    return false
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (!enabled.value) return
+    if (isInputFocused()) return
+
+    const shortcutKey = getShortcutKey(event.key, {
+      ctrl: event.ctrlKey,
+      meta: event.metaKey,
+      shift: event.shiftKey,
+      alt: event.altKey
+    })
+
+    const shortcut = shortcuts.value.get(shortcutKey)
+    if (shortcut) {
+      event.preventDefault()
+      shortcut.handler()
+    }
+  }
+
+  function init(): () => void {
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      shortcuts.value.clear()
+    }
+  }
+
+  function register(
+    key: string,
+    handler: () => void,
+    options: ShortcutOptions = {}
+  ): () => void {
+    const shortcutKey = getShortcutKey(key, options)
+
+    shortcuts.value.set(shortcutKey, {
+      key,
+      handler,
+      options,
+      description: options.description
+    })
+
+    return () => unregister(key, options)
+  }
+
+  function unregister(key: string, options: ShortcutOptions = {}): void {
+    const shortcutKey = getShortcutKey(key, options)
+    shortcuts.value.delete(shortcutKey)
+  }
+
+  function getShortcuts(): RegisteredShortcut[] {
+    return Array.from(shortcuts.value.values())
+  }
+
+  function setEnabled(value: boolean): void {
+    enabled.value = value
+  }
+
+  return {
+    init,
+    register,
+    unregister,
+    getShortcuts,
+    setEnabled,
+    enabled
+  }
+}


### PR DESCRIPTION
## Summary

- 新增 useKeyboardShortcuts composable (`src/composables/useKeyboardShortcuts.ts`)
  - 支援快捷鍵註冊與解除
  - 支援組合鍵 (Ctrl/Meta/Shift/Alt)
  - 支援輸入框自動忽略
  - 支援啟用/停用切換
- 新增 KeyboardShortcutsModal (`src/components/KeyboardShortcutsModal.vue`) 快捷鍵說明對話框
- 整合全域快捷鍵至 App.vue：
  - `Cmd/Ctrl + K` 開啟快速搜尋
  - `?` 顯示快捷鍵說明
  - `b` 開啟專案列表
  - `Esc` 關閉對話框

## Test Plan

- [x] 新增 17 個單元測試 (`src/__tests__/keyboard-shortcuts.test.ts`)
- [x] 所有 330 個測試通過

Closes #53