### PR TITLE
feat(theme): 新增深色模式切換功能

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,21 +2,25 @@
 import { ref, onMounted, onUnmounted, provide } from 'vue'
 import { RouterView, useRouter } from 'vue-router'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
+import { useTheme } from '@/composables/useTheme'
 import KeyboardShortcutsModal from '@/components/KeyboardShortcutsModal.vue'
 import SearchModal from '@/components/SearchModal.vue'
 
 const router = useRouter()
 const shortcuts = useKeyboardShortcuts()
+const theme = useTheme()
 const showShortcutsModal = ref(false)
 const showSearchModal = ref(false)
 
-// Provide shortcuts to child components
+// Provide shortcuts and theme to child components
 provide('shortcuts', shortcuts)
+provide('theme', theme)
 
 let cleanup: (() => void) | null = null
 
 onMounted(() => {
   cleanup = shortcuts.init()
+  theme.init()
 
   // Global shortcuts
   shortcuts.register('?', () => {

--- a/src/__tests__/theme.test.ts
+++ b/src/__tests__/theme.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useTheme, type ThemeMode } from '@/composables/useTheme'
+
+describe('useTheme', () => {
+  let theme: ReturnType<typeof useTheme>
+
+  beforeEach(() => {
+    // Clear localStorage
+    localStorage.clear()
+
+    // Reset document class
+    document.documentElement.classList.remove('dark', 'light')
+
+    // Mock matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-color-scheme: dark)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn()
+      }))
+    })
+
+    theme = useTheme()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('initial state', () => {
+    it('should default to system mode', () => {
+      expect(theme.mode.value).toBe('system')
+    })
+
+    it('should apply dark class when system prefers dark', () => {
+      theme.init()
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+  })
+
+  describe('setMode', () => {
+    it('should set light mode', () => {
+      theme.setMode('light')
+
+      expect(theme.mode.value).toBe('light')
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
+
+    it('should set dark mode', () => {
+      theme.setMode('dark')
+
+      expect(theme.mode.value).toBe('dark')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+
+    it('should set system mode', () => {
+      theme.setMode('system')
+
+      expect(theme.mode.value).toBe('system')
+    })
+
+    it('should persist preference to localStorage', () => {
+      theme.setMode('dark')
+
+      expect(localStorage.getItem('theme-mode')).toBe('dark')
+    })
+  })
+
+  describe('toggle', () => {
+    it('should toggle from light to dark', () => {
+      theme.setMode('light')
+      theme.toggle()
+
+      expect(theme.mode.value).toBe('dark')
+    })
+
+    it('should toggle from dark to light', () => {
+      theme.setMode('dark')
+      theme.toggle()
+
+      expect(theme.mode.value).toBe('light')
+    })
+
+    it('should toggle from system to dark when system prefers light', () => {
+      // Mock system prefers light
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+
+      const newTheme = useTheme()
+      newTheme.setMode('system')
+      newTheme.toggle()
+
+      expect(newTheme.mode.value).toBe('dark')
+    })
+  })
+
+  describe('isDark', () => {
+    it('should return true when dark mode is set', () => {
+      theme.setMode('dark')
+
+      expect(theme.isDark.value).toBe(true)
+    })
+
+    it('should return false when light mode is set', () => {
+      theme.setMode('light')
+
+      expect(theme.isDark.value).toBe(false)
+    })
+
+    it('should return true when system mode and system prefers dark', () => {
+      theme.init()
+      theme.setMode('system')
+
+      expect(theme.isDark.value).toBe(true)
+    })
+  })
+
+  describe('restore from localStorage', () => {
+    it('should restore saved preference', () => {
+      localStorage.setItem('theme-mode', 'dark')
+
+      const newTheme = useTheme()
+      newTheme.init()
+
+      expect(newTheme.mode.value).toBe('dark')
+    })
+
+    it('should use system mode if no saved preference', () => {
+      const newTheme = useTheme()
+      newTheme.init()
+
+      expect(newTheme.mode.value).toBe('system')
+    })
+  })
+})

--- a/src/components/ThemeToggle.vue
+++ b/src/components/ThemeToggle.vue
@@ -1,0 +1,183 @@
+<template>
+  <div class="relative">
+    <button
+      @click="showMenu = !showMenu"
+      class="p-2 rounded-lg text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+      :title="currentLabel"
+    >
+      <!-- Sun icon (light mode) -->
+      <svg
+        v-if="!isDark"
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+        />
+      </svg>
+      <!-- Moon icon (dark mode) -->
+      <svg
+        v-else
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+        />
+      </svg>
+    </button>
+
+    <!-- Dropdown menu -->
+    <Transition name="dropdown">
+      <div
+        v-if="showMenu"
+        class="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-800 rounded-lg shadow-lg ring-1 ring-black/5 dark:ring-white/10 z-50"
+      >
+        <div class="py-1">
+          <button
+            v-for="option in options"
+            :key="option.value"
+            @click="selectMode(option.value)"
+            class="w-full px-4 py-2 text-left text-sm flex items-center gap-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            :class="mode === option.value ? 'text-blue-600 dark:text-blue-400' : 'text-gray-700 dark:text-gray-300'"
+          >
+            <component :is="option.icon" class="h-4 w-4" />
+            {{ option.label }}
+            <svg
+              v-if="mode === option.value"
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-4 w-4 ml-auto"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, h } from 'vue'
+import { useTheme, type ThemeMode } from '@/composables/useTheme'
+
+const theme = useTheme()
+const { mode, isDark, setMode } = theme
+
+const showMenu = ref(false)
+
+const currentLabel = computed(() => {
+  const labels: Record<ThemeMode, string> = {
+    light: '淺色模式',
+    dark: '深色模式',
+    system: '系統預設'
+  }
+  return labels[mode.value]
+})
+
+// Icon components
+const SunIcon = {
+  render: () => h('svg', {
+    xmlns: 'http://www.w3.org/2000/svg',
+    class: 'h-4 w-4',
+    fill: 'none',
+    viewBox: '0 0 24 24',
+    stroke: 'currentColor'
+  }, [
+    h('path', {
+      'stroke-linecap': 'round',
+      'stroke-linejoin': 'round',
+      'stroke-width': '2',
+      d: 'M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z'
+    })
+  ])
+}
+
+const MoonIcon = {
+  render: () => h('svg', {
+    xmlns: 'http://www.w3.org/2000/svg',
+    class: 'h-4 w-4',
+    fill: 'none',
+    viewBox: '0 0 24 24',
+    stroke: 'currentColor'
+  }, [
+    h('path', {
+      'stroke-linecap': 'round',
+      'stroke-linejoin': 'round',
+      'stroke-width': '2',
+      d: 'M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z'
+    })
+  ])
+}
+
+const ComputerIcon = {
+  render: () => h('svg', {
+    xmlns: 'http://www.w3.org/2000/svg',
+    class: 'h-4 w-4',
+    fill: 'none',
+    viewBox: '0 0 24 24',
+    stroke: 'currentColor'
+  }, [
+    h('path', {
+      'stroke-linecap': 'round',
+      'stroke-linejoin': 'round',
+      'stroke-width': '2',
+      d: 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z'
+    })
+  ])
+}
+
+const options = [
+  { value: 'light' as ThemeMode, label: '淺色模式', icon: SunIcon },
+  { value: 'dark' as ThemeMode, label: '深色模式', icon: MoonIcon },
+  { value: 'system' as ThemeMode, label: '系統預設', icon: ComputerIcon }
+]
+
+function selectMode(newMode: ThemeMode) {
+  setMode(newMode)
+  showMenu.value = false
+}
+
+function handleClickOutside(event: MouseEvent) {
+  const target = event.target as HTMLElement
+  if (!target.closest('.relative')) {
+    showMenu.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+</script>
+
+<style scoped>
+.dropdown-enter-active,
+.dropdown-leave-active {
+  transition: opacity 0.1s ease, transform 0.1s ease;
+}
+
+.dropdown-enter-from,
+.dropdown-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+</style>

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -1,0 +1,72 @@
+import { ref, computed, watch } from 'vue'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+const STORAGE_KEY = 'theme-mode'
+
+export function useTheme() {
+  const mode = ref<ThemeMode>('system')
+
+  const systemPrefersDark = computed(() => {
+    if (typeof window === 'undefined') return false
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  })
+
+  const isDark = computed(() => {
+    if (mode.value === 'dark') return true
+    if (mode.value === 'light') return false
+    return systemPrefersDark.value
+  })
+
+  function applyTheme() {
+    if (isDark.value) {
+      document.documentElement.classList.add('dark')
+      document.documentElement.classList.remove('light')
+    } else {
+      document.documentElement.classList.remove('dark')
+      document.documentElement.classList.add('light')
+    }
+  }
+
+  function setMode(newMode: ThemeMode) {
+    mode.value = newMode
+    localStorage.setItem(STORAGE_KEY, newMode)
+    applyTheme()
+  }
+
+  function toggle() {
+    if (mode.value === 'system') {
+      setMode(isDark.value ? 'light' : 'dark')
+    } else {
+      setMode(mode.value === 'dark' ? 'light' : 'dark')
+    }
+  }
+
+  function init() {
+    const saved = localStorage.getItem(STORAGE_KEY) as ThemeMode | null
+    if (saved && ['light', 'dark', 'system'].includes(saved)) {
+      mode.value = saved
+    }
+    applyTheme()
+
+    // Listen for system preference changes
+    if (typeof window !== 'undefined') {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      mediaQuery.addEventListener('change', () => {
+        if (mode.value === 'system') {
+          applyTheme()
+        }
+      })
+    }
+  }
+
+  watch(mode, applyTheme)
+
+  return {
+    mode,
+    isDark,
+    setMode,
+    toggle,
+    init
+  }
+}


### PR DESCRIPTION
## Summary

- 新增 useTheme composable (`src/composables/useTheme.ts`)
  - 支援淺色 (light)、深色 (dark)、系統 (system) 三種模式
  - 自動偵測系統偏好設定
  - 儲存使用者偏好至 localStorage
  - 監聽系統偏好變更
- 新增 ThemeToggle 主題切換元件 (`src/components/ThemeToggle.vue`)
  - 顯示目前主題狀態
  - 下拉選單切換主題
- 整合主題系統至 App.vue

## Test Plan

- [x] 新增 14 個單元測試 (`src/__tests__/theme.test.ts`)
- [x] 所有 344 個測試通過

Closes #55