### PR TITLE
feat(tauri): 新增 Tauri Desktop 前端整合

### DIFF
--- a/src/__tests__/tauri.test.ts
+++ b/src/__tests__/tauri.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useTauri } from '@/composables/useTauri'
+
+describe('useTauri', () => {
+  let tauri: ReturnType<typeof useTauri>
+
+  beforeEach(() => {
+    // Clear any window.__TAURI__ mock
+    delete (window as unknown as Record<string, unknown>).__TAURI__
+    tauri = useTauri()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('isTauri', () => {
+    it('should return false in browser environment', () => {
+      expect(tauri.isTauri.value).toBe(false)
+    })
+
+    it('should return true when __TAURI__ exists', () => {
+      ;(window as unknown as Record<string, unknown>).__TAURI__ = {}
+      const newTauri = useTauri()
+      expect(newTauri.isTauri.value).toBe(true)
+    })
+  })
+
+  describe('storage', () => {
+    it('should use localStorage when not in Tauri', async () => {
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+      const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('test-value')
+
+      await tauri.storage.set('key', 'value')
+      expect(setItemSpy).toHaveBeenCalledWith('key', 'value')
+
+      const result = await tauri.storage.get('key')
+      expect(getItemSpy).toHaveBeenCalledWith('key')
+      expect(result).toBe('test-value')
+    })
+
+    it('should remove item from localStorage', async () => {
+      const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem')
+
+      await tauri.storage.remove('key')
+      expect(removeItemSpy).toHaveBeenCalledWith('key')
+    })
+  })
+
+  describe('notifications', () => {
+    it('should check notification permission', async () => {
+      expect(typeof tauri.notifications.isPermissionGranted).toBe('function')
+    })
+
+    it('should request notification permission', async () => {
+      expect(typeof tauri.notifications.requestPermission).toBe('function')
+    })
+
+    it('should send notification', async () => {
+      expect(typeof tauri.notifications.sendNotification).toBe('function')
+    })
+  })
+
+  describe('window', () => {
+    it('should have minimize function', () => {
+      expect(typeof tauri.window.minimize).toBe('function')
+    })
+
+    it('should have close function', () => {
+      expect(typeof tauri.window.close).toBe('function')
+    })
+
+    it('should have hide function', () => {
+      expect(typeof tauri.window.hide).toBe('function')
+    })
+
+    it('should have show function', () => {
+      expect(typeof tauri.window.show).toBe('function')
+    })
+  })
+})

--- a/src/composables/useTauri.ts
+++ b/src/composables/useTauri.ts
@@ -1,0 +1,192 @@
+import { computed } from 'vue'
+
+// Check if running in Tauri environment
+function checkIsTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI__' in window
+}
+
+// Dynamic import helper with fallback
+async function importTauriModule<T>(moduleName: string): Promise<T | null> {
+  if (!checkIsTauri()) return null
+  try {
+    return await import(/* @vite-ignore */ moduleName) as T
+  } catch {
+    return null
+  }
+}
+
+export function useTauri() {
+  const isTauri = computed(() => checkIsTauri())
+
+  // Storage API - falls back to localStorage when not in Tauri
+  const storage = {
+    async get(key: string): Promise<string | null> {
+      if (checkIsTauri()) {
+        try {
+          const core = await importTauriModule<{ invoke: <T>(cmd: string, args?: unknown) => Promise<T> }>('@tauri-apps/api/core')
+          if (core) {
+            return await core.invoke<string | null>('get_storage', { key })
+          }
+        } catch {
+          // Fall through to localStorage
+        }
+      }
+      return localStorage.getItem(key)
+    },
+
+    async set(key: string, value: string): Promise<void> {
+      if (checkIsTauri()) {
+        try {
+          const core = await importTauriModule<{ invoke: <T>(cmd: string, args?: unknown) => Promise<T> }>('@tauri-apps/api/core')
+          if (core) {
+            await core.invoke('set_storage', { key, value })
+            return
+          }
+        } catch {
+          // Fall through to localStorage
+        }
+      }
+      localStorage.setItem(key, value)
+    },
+
+    async remove(key: string): Promise<void> {
+      if (checkIsTauri()) {
+        try {
+          const core = await importTauriModule<{ invoke: <T>(cmd: string, args?: unknown) => Promise<T> }>('@tauri-apps/api/core')
+          if (core) {
+            await core.invoke('remove_storage', { key })
+            return
+          }
+        } catch {
+          // Fall through to localStorage
+        }
+      }
+      localStorage.removeItem(key)
+    }
+  }
+
+  // Notifications API
+  const notifications = {
+    async isPermissionGranted(): Promise<boolean> {
+      if (checkIsTauri()) {
+        try {
+          const notification = await importTauriModule<{ isPermissionGranted: () => Promise<boolean> }>('@tauri-apps/plugin-notification')
+          if (notification) {
+            return await notification.isPermissionGranted()
+          }
+        } catch {
+          // Fall through to web API
+        }
+      }
+      if ('Notification' in window) {
+        return Notification.permission === 'granted'
+      }
+      return false
+    },
+
+    async requestPermission(): Promise<boolean> {
+      if (checkIsTauri()) {
+        try {
+          const notification = await importTauriModule<{ requestPermission: () => Promise<string> }>('@tauri-apps/plugin-notification')
+          if (notification) {
+            const permission = await notification.requestPermission()
+            return permission === 'granted'
+          }
+        } catch {
+          // Fall through to web API
+        }
+      }
+      if ('Notification' in window) {
+        const result = await Notification.requestPermission()
+        return result === 'granted'
+      }
+      return false
+    },
+
+    async sendNotification(title: string, body?: string): Promise<void> {
+      if (checkIsTauri()) {
+        try {
+          const notification = await importTauriModule<{ sendNotification: (options: { title: string; body?: string }) => Promise<void> }>('@tauri-apps/plugin-notification')
+          if (notification) {
+            await notification.sendNotification({ title, body })
+            return
+          }
+        } catch {
+          // Fall through to web notification
+        }
+      }
+      if ('Notification' in window && Notification.permission === 'granted') {
+        new Notification(title, { body })
+      }
+    }
+  }
+
+  // Window API
+  interface TauriWindow {
+    minimize: () => Promise<void>
+    close: () => Promise<void>
+    hide: () => Promise<void>
+    show: () => Promise<void>
+  }
+
+  const windowApi = {
+    async minimize(): Promise<void> {
+      if (checkIsTauri()) {
+        try {
+          const windowModule = await importTauriModule<{ getCurrentWindow: () => TauriWindow }>('@tauri-apps/api/window')
+          if (windowModule) {
+            await windowModule.getCurrentWindow().minimize()
+          }
+        } catch {
+          // Not in Tauri, no-op
+        }
+      }
+    },
+
+    async close(): Promise<void> {
+      if (checkIsTauri()) {
+        try {
+          const windowModule = await importTauriModule<{ getCurrentWindow: () => TauriWindow }>('@tauri-apps/api/window')
+          if (windowModule) {
+            await windowModule.getCurrentWindow().close()
+          }
+        } catch {
+          // Not in Tauri, no-op
+        }
+      }
+    },
+
+    async hide(): Promise<void> {
+      if (checkIsTauri()) {
+        try {
+          const windowModule = await importTauriModule<{ getCurrentWindow: () => TauriWindow }>('@tauri-apps/api/window')
+          if (windowModule) {
+            await windowModule.getCurrentWindow().hide()
+          }
+        } catch {
+          // Not in Tauri, no-op
+        }
+      }
+    },
+
+    async show(): Promise<void> {
+      if (checkIsTauri()) {
+        try {
+          const windowModule = await importTauriModule<{ getCurrentWindow: () => TauriWindow }>('@tauri-apps/api/window')
+          if (windowModule) {
+            await windowModule.getCurrentWindow().show()
+          }
+        } catch {
+          // Not in Tauri, no-op
+        }
+      }
+    }
+  }
+
+  return {
+    isTauri,
+    storage,
+    notifications,
+    window: windowApi
+  }
+}


### PR DESCRIPTION
## Summary

- 新增 useTauri composable (`src/composables/useTauri.ts`)
  - 自動偵測 Tauri 環境
  - 提供 `isTauri` computed 屬性
- 安全儲存 API (`storage`)
  - `get(key)` - 取得儲存值
  - `set(key, value)` - 設定儲存值
  - `remove(key)` - 移除儲存值
  - 非 Tauri 環境自動 fallback 至 localStorage
- 通知 API (`notifications`)
  - `isPermissionGranted()` - 檢查通知權限
  - `requestPermission()` - 請求通知權限
  - `sendNotification(title, body)` - 發送通知
  - 非 Tauri 環境自動 fallback 至 Web Notification API
- 視窗控制 API (`window`)
  - `minimize()` - 最小化視窗
  - `close()` - 關閉視窗
  - `hide()` - 隱藏視窗
  - `show()` - 顯示視窗

## Test Plan

- [x] 新增 11 個單元測試 (`src/__tests__/tauri.test.ts`)
- [x] 所有 355 個測試通過

## 備註

完整的 Tauri 後端整合（Rust 程式碼）將在後續 PR 中實作

Closes #57