### PR TITLE
feat(keyboard): 新增序列快捷鍵和上下文感知快捷鍵

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,0 +1,9 @@
+---
+active: true
+iteration: 5
+max_iterations: 100
+completion_promise: null
+started_at: "2026-01-12T18:31:34Z"
+---
+
+依據 @CLAUDE.md 開發規範，完成 @docs/TODO.md 待開發項目，所有項目完成後輸出 TODO-COMPLETE

--- a/src/__tests__/keyboard-shortcuts.test.ts
+++ b/src/__tests__/keyboard-shortcuts.test.ts
@@ -214,4 +214,134 @@ describe('useKeyboardShortcuts', () => {
       expect(handler).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('sequence shortcuts', () => {
+    it('should register sequence shortcut v+b', async () => {
+      const handler = vi.fn()
+      shortcuts.registerSequence(['v', 'b'], handler, { description: 'Board view' })
+
+      dispatchKeyEvent('v')
+      await new Promise(resolve => setTimeout(resolve, 50))
+      dispatchKeyEvent('b')
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should register sequence shortcut v+l', async () => {
+      const handler = vi.fn()
+      shortcuts.registerSequence(['v', 'l'], handler, { description: 'List view' })
+
+      dispatchKeyEvent('v')
+      await new Promise(resolve => setTimeout(resolve, 50))
+      dispatchKeyEvent('l')
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should register sequence shortcut v+c', async () => {
+      const handler = vi.fn()
+      shortcuts.registerSequence(['v', 'c'], handler, { description: 'Calendar view' })
+
+      dispatchKeyEvent('v')
+      await new Promise(resolve => setTimeout(resolve, 50))
+      dispatchKeyEvent('c')
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should timeout sequence after delay', async () => {
+      const handler = vi.fn()
+      shortcuts.registerSequence(['v', 'b'], handler)
+
+      dispatchKeyEvent('v')
+      await new Promise(resolve => setTimeout(resolve, 600))
+      dispatchKeyEvent('b')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should reset sequence on wrong key', async () => {
+      const handler = vi.fn()
+      shortcuts.registerSequence(['v', 'b'], handler)
+
+      dispatchKeyEvent('v')
+      await new Promise(resolve => setTimeout(resolve, 50))
+      dispatchKeyEvent('x')
+      dispatchKeyEvent('b')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should unregister sequence shortcut', async () => {
+      const handler = vi.fn()
+      const unregister = shortcuts.registerSequence(['v', 'b'], handler)
+
+      unregister()
+      dispatchKeyEvent('v')
+      await new Promise(resolve => setTimeout(resolve, 50))
+      dispatchKeyEvent('b')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('context shortcuts', () => {
+    it('should register context-aware shortcut', () => {
+      const handler = vi.fn()
+      shortcuts.registerWithContext('n', handler, {
+        context: 'board',
+        description: 'New task'
+      })
+
+      shortcuts.setContext('board')
+      dispatchKeyEvent('n')
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not trigger shortcut in wrong context', () => {
+      const handler = vi.fn()
+      shortcuts.registerWithContext('n', handler, { context: 'board' })
+
+      shortcuts.setContext('list')
+      dispatchKeyEvent('n')
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should trigger global shortcuts in any context', () => {
+      const handler = vi.fn()
+      shortcuts.register('?', handler)
+
+      shortcuts.setContext('board')
+      dispatchKeyEvent('?')
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should get current context', () => {
+      shortcuts.setContext('task-detail')
+      expect(shortcuts.getContext()).toBe('task-detail')
+    })
+  })
+
+  describe('ctrl/meta + Enter', () => {
+    it('should register ctrl+Enter shortcut', () => {
+      const handler = vi.fn()
+      shortcuts.register('Enter', handler, { ctrl: true, description: 'Submit form' })
+
+      dispatchKeyEvent('Enter', { ctrlKey: true })
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should register meta+Enter shortcut', () => {
+      const handler = vi.fn()
+      shortcuts.register('Enter', handler, { meta: true, description: 'Submit form' })
+
+      dispatchKeyEvent('Enter', { metaKey: true })
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -8,10 +8,21 @@ export interface ShortcutOptions {
   description?: string
 }
 
+export interface ContextShortcutOptions extends ShortcutOptions {
+  context: string
+}
+
 export interface RegisteredShortcut {
   key: string
   handler: () => void
   options: ShortcutOptions
+  description?: string
+  context?: string
+}
+
+export interface SequenceShortcut {
+  keys: string[]
+  handler: () => void
   description?: string
 }
 
@@ -27,7 +38,14 @@ function getShortcutKey(key: string, options: ShortcutOptions = {}): string {
 
 export function useKeyboardShortcuts() {
   const shortcuts = ref<Map<string, RegisteredShortcut>>(new Map())
+  const sequences = ref<Map<string, SequenceShortcut>>(new Map())
   const enabled = ref(true)
+  const currentContext = ref<string>('global')
+
+  // Sequence tracking
+  let sequenceBuffer: string[] = []
+  let sequenceTimeout: ReturnType<typeof setTimeout> | null = null
+  const SEQUENCE_TIMEOUT = 500
 
   function isInputFocused(): boolean {
     const activeElement = document.activeElement
@@ -45,9 +63,55 @@ export function useKeyboardShortcuts() {
     return false
   }
 
+  function resetSequence(): void {
+    sequenceBuffer = []
+    if (sequenceTimeout) {
+      clearTimeout(sequenceTimeout)
+      sequenceTimeout = null
+    }
+  }
+
+  function checkSequence(key: string): boolean {
+    sequenceBuffer.push(key.toLowerCase())
+
+    // Check if current buffer matches any registered sequence
+    for (const [seqKey, seq] of sequences.value.entries()) {
+      const bufferStr = sequenceBuffer.join('+')
+      const seqStr = seq.keys.join('+').toLowerCase()
+
+      if (bufferStr === seqStr) {
+        resetSequence()
+        seq.handler()
+        return true
+      }
+
+      // Check if current buffer is a prefix of any sequence
+      if (seqStr.startsWith(bufferStr)) {
+        // Set timeout to reset sequence
+        if (sequenceTimeout) {
+          clearTimeout(sequenceTimeout)
+        }
+        sequenceTimeout = setTimeout(resetSequence, SEQUENCE_TIMEOUT)
+        return true
+      }
+    }
+
+    // No match and not a prefix, reset
+    resetSequence()
+    return false
+  }
+
   function handleKeyDown(event: KeyboardEvent): void {
     if (!enabled.value) return
     if (isInputFocused()) return
+
+    // Check for sequence shortcuts first (only for simple keys without modifiers)
+    if (!event.ctrlKey && !event.metaKey && !event.altKey && sequences.value.size > 0) {
+      if (checkSequence(event.key)) {
+        event.preventDefault()
+        return
+      }
+    }
 
     const shortcutKey = getShortcutKey(event.key, {
       ctrl: event.ctrlKey,
@@ -56,6 +120,15 @@ export function useKeyboardShortcuts() {
       alt: event.altKey
     })
 
+    // First try context-specific shortcut
+    const contextShortcut = shortcuts.value.get(shortcutKey + ':' + currentContext.value)
+    if (contextShortcut) {
+      event.preventDefault()
+      contextShortcut.handler()
+      return
+    }
+
+    // Then try global shortcut
     const shortcut = shortcuts.value.get(shortcutKey)
     if (shortcut) {
       event.preventDefault()
@@ -69,6 +142,8 @@ export function useKeyboardShortcuts() {
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
       shortcuts.value.clear()
+      sequences.value.clear()
+      resetSequence()
     }
   }
 
@@ -89,6 +164,44 @@ export function useKeyboardShortcuts() {
     return () => unregister(key, options)
   }
 
+  function registerSequence(
+    keys: string[],
+    handler: () => void,
+    options: { description?: string } = {}
+  ): () => void {
+    const seqKey = keys.join('+').toLowerCase()
+
+    sequences.value.set(seqKey, {
+      keys,
+      handler,
+      description: options.description
+    })
+
+    return () => {
+      sequences.value.delete(seqKey)
+    }
+  }
+
+  function registerWithContext(
+    key: string,
+    handler: () => void,
+    options: ContextShortcutOptions
+  ): () => void {
+    const shortcutKey = getShortcutKey(key, options)
+
+    shortcuts.value.set(shortcutKey + ':' + options.context, {
+      key,
+      handler,
+      options,
+      description: options.description,
+      context: options.context
+    })
+
+    return () => {
+      shortcuts.value.delete(shortcutKey + ':' + options.context)
+    }
+  }
+
   function unregister(key: string, options: ShortcutOptions = {}): void {
     const shortcutKey = getShortcutKey(key, options)
     shortcuts.value.delete(shortcutKey)
@@ -102,12 +215,24 @@ export function useKeyboardShortcuts() {
     enabled.value = value
   }
 
+  function setContext(context: string): void {
+    currentContext.value = context
+  }
+
+  function getContext(): string {
+    return currentContext.value
+  }
+
   return {
     init,
     register,
+    registerSequence,
+    registerWithContext,
     unregister,
     getShortcuts,
     setEnabled,
+    setContext,
+    getContext,
     enabled
   }
 }


### PR DESCRIPTION
## Summary
- 新增 `registerSequence` 方法支援如 `v+b`, `v+l`, `v+c` 等組合鍵
- 新增 `registerWithContext` 方法支援頁面上下文感知快捷鍵
- 新增 `setContext`/`getContext` 方法管理當前上下文
- 序列鍵有 500ms 超時機制

## Test plan
- [x] 12 個新測試案例全部通過
- [x] 367 個測試全部通過

Closes #59