### PR TITLE
feat(analytics): 新增進階分析圖表功能

### DIFF
--- a/src/__tests__/analytics-store.test.ts
+++ b/src/__tests__/analytics-store.test.ts
@@ -325,4 +325,140 @@ describe('Analytics Store', () => {
       expect(store.error).toBeNull()
     })
   })
+
+  describe('calculateCumulativeFlow', () => {
+    it('should calculate cumulative flow data', () => {
+      const store = useAnalyticsStore()
+      const tasksWithDates: Task[] = [
+        { ...mockTasks[0], column_id: 1, date_creation: 1704067200, date_moved: 1704153600 },
+        { ...mockTasks[1], column_id: 2, date_creation: 1704067200, date_moved: 1704240000 },
+        { ...mockTasks[2], column_id: 3, date_creation: 1704153600, date_moved: 1704326400 }
+      ]
+
+      const flowData = store.calculateCumulativeFlow(tasksWithDates, mockColumns, '2024-01-01', '2024-01-05')
+
+      expect(flowData.length).toBeGreaterThan(0)
+      expect(flowData[0]).toHaveProperty('date')
+      expect(flowData[0]).toHaveProperty('columns')
+    })
+
+    it('should return empty array for empty tasks', () => {
+      const store = useAnalyticsStore()
+
+      const flowData = store.calculateCumulativeFlow([], mockColumns, '2024-01-01', '2024-01-05')
+
+      expect(flowData).toEqual([])
+    })
+  })
+
+  describe('calculateBurndown', () => {
+    it('should calculate burndown data', () => {
+      const store = useAnalyticsStore()
+      const tasksWithDates: Task[] = [
+        { ...mockTasks[0], is_active: false, date_completed: 1704153600 },
+        { ...mockTasks[1], is_active: false, date_completed: 1704240000 },
+        { ...mockTasks[2], is_active: true }
+      ]
+
+      const burndownData = store.calculateBurndown(tasksWithDates, '2024-01-01', '2024-01-05')
+
+      expect(burndownData.length).toBeGreaterThan(0)
+      expect(burndownData[0]).toHaveProperty('date')
+      expect(burndownData[0]).toHaveProperty('remaining')
+      expect(burndownData[0]).toHaveProperty('ideal')
+    })
+
+    it('should return empty array for empty tasks', () => {
+      const store = useAnalyticsStore()
+
+      const burndownData = store.calculateBurndown([], '2024-01-01', '2024-01-05')
+
+      expect(burndownData).toEqual([])
+    })
+
+    it('should show decreasing remaining count', () => {
+      const store = useAnalyticsStore()
+      const tasksWithDates: Task[] = [
+        { ...mockTasks[0], is_active: false, date_completed: 1704153600 },
+        { ...mockTasks[1], is_active: false, date_completed: 1704240000 },
+        { ...mockTasks[2], is_active: true }
+      ]
+
+      const burndownData = store.calculateBurndown(tasksWithDates, '2024-01-01', '2024-01-05')
+      const firstRemaining = burndownData[0]?.remaining ?? 0
+      const lastRemaining = burndownData[burndownData.length - 1]?.remaining ?? 0
+
+      expect(lastRemaining).toBeLessThanOrEqual(firstRemaining)
+    })
+  })
+
+  describe('calculateColumnTime', () => {
+    it('should calculate average time in each column', () => {
+      const store = useAnalyticsStore()
+      store.activities = [
+        { id: 1, date_creation: 1704067200, event_name: 'task.move.column', creator_id: 1, project_id: 1, task_id: 1, data: { src_column_id: 1, dst_column_id: 2 } },
+        { id: 2, date_creation: 1704153600, event_name: 'task.move.column', creator_id: 1, project_id: 1, task_id: 1, data: { src_column_id: 2, dst_column_id: 3 } }
+      ]
+
+      const columnTime = store.calculateColumnTime(mockColumns)
+
+      expect(columnTime.length).toBe(3)
+      expect(columnTime[0]).toHaveProperty('column')
+      expect(columnTime[0]).toHaveProperty('avgDays')
+    })
+
+    it('should return zero days for columns with no movement', () => {
+      const store = useAnalyticsStore()
+      store.activities = []
+
+      const columnTime = store.calculateColumnTime(mockColumns)
+
+      expect(columnTime.every(ct => ct.avgDays === 0)).toBe(true)
+    })
+  })
+
+  describe('calculateLeadCycleTime', () => {
+    it('should calculate lead and cycle time', () => {
+      const store = useAnalyticsStore()
+      const completedTasks: Task[] = [
+        { ...mockTasks[0], is_active: false, date_creation: 1704067200, date_started: 1704153600, date_completed: 1704326400 },
+        { ...mockTasks[1], is_active: false, date_creation: 1704067200, date_started: 1704240000, date_completed: 1704412800 }
+      ]
+
+      const leadCycleData = store.calculateLeadCycleTime(completedTasks)
+
+      expect(leadCycleData).toHaveProperty('avgLeadTime')
+      expect(leadCycleData).toHaveProperty('avgCycleTime')
+      expect(leadCycleData).toHaveProperty('tasks')
+      expect(leadCycleData.avgLeadTime).toBeGreaterThan(0)
+    })
+
+    it('should return zero for empty tasks', () => {
+      const store = useAnalyticsStore()
+
+      const leadCycleData = store.calculateLeadCycleTime([])
+
+      expect(leadCycleData.avgLeadTime).toBe(0)
+      expect(leadCycleData.avgCycleTime).toBe(0)
+      expect(leadCycleData.tasks).toEqual([])
+    })
+
+    it('should calculate lead time as time from creation to completion', () => {
+      const store = useAnalyticsStore()
+      const task: Task = {
+        ...mockTasks[0],
+        is_active: false,
+        date_creation: 1704067200, // 2024-01-01
+        date_started: 1704153600,  // 2024-01-02
+        date_completed: 1704326400 // 2024-01-04
+      }
+
+      const leadCycleData = store.calculateLeadCycleTime([task])
+
+      // Lead time: 3 days (Jan 1 to Jan 4)
+      expect(leadCycleData.avgLeadTime).toBe(3)
+      // Cycle time: 2 days (Jan 2 to Jan 4)
+      expect(leadCycleData.avgCycleTime).toBe(2)
+    })
+  })
 })

--- a/src/stores/analytics.ts
+++ b/src/stores/analytics.ts
@@ -26,6 +26,35 @@ export interface ActivityStats {
   taskClosed: number
 }
 
+export interface CumulativeFlowData {
+  date: string
+  columns: Record<string, number>
+}
+
+export interface BurndownData {
+  date: string
+  remaining: number
+  ideal: number
+}
+
+export interface ColumnTimeData {
+  column: string
+  avgDays: number
+}
+
+export interface TaskLeadCycleData {
+  taskId: number
+  title: string
+  leadTime: number
+  cycleTime: number
+}
+
+export interface LeadCycleTimeData {
+  avgLeadTime: number
+  avgCycleTime: number
+  tasks: TaskLeadCycleData[]
+}
+
 export const useAnalyticsStore = defineStore('analytics', () => {
   const activities = ref<Activity[]>([])
   const isLoading = ref(false)
@@ -109,6 +138,169 @@ export const useAnalyticsStore = defineStore('analytics', () => {
     error.value = null
   }
 
+  function calculateCumulativeFlow(
+    tasks: Task[],
+    columns: Column[],
+    startDate: string,
+    endDate: string
+  ): CumulativeFlowData[] {
+    if (tasks.length === 0) return []
+
+    const result: CumulativeFlowData[] = []
+    const start = new Date(startDate)
+    const end = new Date(endDate)
+
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+      const dateStr = d.toISOString().split('T')[0]
+      const dateTimestamp = d.getTime() / 1000
+
+      const columnCounts: Record<string, number> = {}
+      columns.forEach(col => {
+        columnCounts[col.title] = 0
+      })
+
+      tasks.forEach(task => {
+        // Count tasks that existed on this date
+        if (task.date_creation <= dateTimestamp) {
+          const column = columns.find(c => c.id === task.column_id)
+          if (column) {
+            columnCounts[column.title]++
+          }
+        }
+      })
+
+      result.push({
+        date: dateStr,
+        columns: columnCounts
+      })
+    }
+
+    return result
+  }
+
+  function calculateBurndown(
+    tasks: Task[],
+    startDate: string,
+    endDate: string
+  ): BurndownData[] {
+    if (tasks.length === 0) return []
+
+    const result: BurndownData[] = []
+    const start = new Date(startDate)
+    const end = new Date(endDate)
+    const totalTasks = tasks.length
+    const totalDays = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1
+    const idealDecrement = totalTasks / (totalDays - 1)
+
+    let dayIndex = 0
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+      const dateStr = d.toISOString().split('T')[0]
+      const dateTimestamp = d.getTime() / 1000
+
+      // Count remaining (active) tasks
+      const completedByDate = tasks.filter(task => {
+        const dateCompleted = (task as Task & { date_completed?: number }).date_completed
+        return !task.is_active && dateCompleted && dateCompleted <= dateTimestamp
+      }).length
+
+      const remaining = totalTasks - completedByDate
+      const ideal = Math.max(0, totalTasks - (idealDecrement * dayIndex))
+
+      result.push({
+        date: dateStr,
+        remaining,
+        ideal: Math.round(ideal * 100) / 100
+      })
+
+      dayIndex++
+    }
+
+    return result
+  }
+
+  function calculateColumnTime(columns: Column[]): ColumnTimeData[] {
+    const columnTimes: Record<number, number[]> = {}
+    columns.forEach(col => {
+      columnTimes[col.id] = []
+    })
+
+    // Group activities by task
+    const taskMoves: Record<number, { columnId: number; timestamp: number }[]> = {}
+
+    activities.value
+      .filter(a => a.event_name === 'task.move.column')
+      .forEach(activity => {
+        const taskId = activity.task_id
+        if (!taskMoves[taskId]) {
+          taskMoves[taskId] = []
+        }
+
+        const data = activity.data as { src_column_id?: number; dst_column_id?: number } | undefined
+        if (data?.src_column_id) {
+          taskMoves[taskId].push({
+            columnId: data.src_column_id,
+            timestamp: activity.date_creation
+          })
+        }
+      })
+
+    // Calculate time spent in each column
+    Object.values(taskMoves).forEach(moves => {
+      moves.sort((a, b) => a.timestamp - b.timestamp)
+
+      for (let i = 1; i < moves.length; i++) {
+        const prev = moves[i - 1]
+        const curr = moves[i]
+        const daysInColumn = (curr.timestamp - prev.timestamp) / (60 * 60 * 24)
+
+        if (columnTimes[prev.columnId]) {
+          columnTimes[prev.columnId].push(daysInColumn)
+        }
+      }
+    })
+
+    return columns.map(col => ({
+      column: col.title,
+      avgDays: columnTimes[col.id].length > 0
+        ? Math.round((columnTimes[col.id].reduce((a, b) => a + b, 0) / columnTimes[col.id].length) * 100) / 100
+        : 0
+    }))
+  }
+
+  function calculateLeadCycleTime(tasks: Task[]): LeadCycleTimeData {
+    if (tasks.length === 0) {
+      return { avgLeadTime: 0, avgCycleTime: 0, tasks: [] }
+    }
+
+    const taskData: TaskLeadCycleData[] = []
+
+    tasks.forEach(task => {
+      const extTask = task as Task & { date_started?: number; date_completed?: number }
+      if (!extTask.date_completed) return
+
+      const leadTime = Math.round((extTask.date_completed - task.date_creation) / (60 * 60 * 24))
+      const cycleTime = extTask.date_started
+        ? Math.round((extTask.date_completed - extTask.date_started) / (60 * 60 * 24))
+        : leadTime
+
+      taskData.push({
+        taskId: task.id,
+        title: task.title,
+        leadTime,
+        cycleTime
+      })
+    })
+
+    if (taskData.length === 0) {
+      return { avgLeadTime: 0, avgCycleTime: 0, tasks: [] }
+    }
+
+    const avgLeadTime = Math.round(taskData.reduce((sum, t) => sum + t.leadTime, 0) / taskData.length)
+    const avgCycleTime = Math.round(taskData.reduce((sum, t) => sum + t.cycleTime, 0) / taskData.length)
+
+    return { avgLeadTime, avgCycleTime, tasks: taskData }
+  }
+
   return {
     activities,
     isLoading,
@@ -118,6 +310,10 @@ export const useAnalyticsStore = defineStore('analytics', () => {
     calculateUserWorkload,
     calculateActivityByDay,
     getActivityStats,
-    clearAnalytics
+    clearAnalytics,
+    calculateCumulativeFlow,
+    calculateBurndown,
+    calculateColumnTime,
+    calculateLeadCycleTime
   }
 })


### PR DESCRIPTION
## Summary
- 新增 `calculateCumulativeFlow` 累積流程圖計算
- 新增 `calculateBurndown` 燃盡圖計算
- 新增 `calculateColumnTime` 欄位平均停留時間計算
- 新增 `calculateLeadCycleTime` Lead/Cycle Time 計算

## Test plan
- [x] 10 個新測試案例全部通過
- [x] 377 個測試全部通過

Closes #61