### PR TITLE
feat(admin): 新增系統管理功能

### DIFF
--- a/docs/plans/2026-01-22-admin-system-management-design.md
+++ b/docs/plans/2026-01-22-admin-system-management-design.md
@@ -1,0 +1,139 @@
+# 系統管理功能設計文件
+
+## 概述
+
+新增系統管理功能，讓管理員可以查看系統狀態、調整設定、管理使用者與群組。
+
+## 變更範圍
+
+### 1. API 方法更名
+
+將 `getKanproBridgePlugin` 更名為 `getKanproBridgeStatus`：
+- `src/services/api/jwt.ts`
+
+### 2. 路由結構
+
+```
+/admin                → 系統狀態（預設）
+/admin/settings       → 系統設定
+/admin/users          → 使用者管理（已存在，整合）
+/admin/groups         → 群組管理（已存在，整合）
+```
+
+所有 `/admin/*` 路由加入 `meta: { requiresAdmin: true }`。
+
+### 3. Header 導航
+
+當進入 `/admin/*` 路由時，AppHeader 顯示分頁導航：
+
+```
+⚙️ 系統管理  ›  [系統狀態] [系統設定] [使用者管理] [群組管理]
+```
+
+與專案頁面相同的 topbar 分頁樣式。
+
+### 4. UserDropdown 變更
+
+在「個人設定」與「樣板風格」之間加入「系統管理」選項，僅 `app-admin` 角色可見。
+
+## 頁面設計
+
+### 系統狀態頁面 (`/admin`)
+
+左右雙欄佈局：
+
+**左側 - Kanboard 伺服器**
+- 版本（`getVersion`）
+- 時區（`getTimezone`）
+- API 位址
+- 連線狀態（含延遲 ms）
+
+**右側 - KanproBridge 外掛**
+- 版本
+- 模組狀態列表：
+  - JWT 認證 → 登入驗證、Token 管理
+  - 使用者頭像 → 頭像上傳與顯示
+  - 使用者元資料 → 偏好設定儲存
+  - 密碼管理 → 密碼變更功能
+  - 使用者設定檔 → 個人資料編輯
+
+**狀態指示**
+- `●` 綠色燈號 + 正常文字 = 已啟用
+- `○` 灰色燈號 + 淡色文字 = 未啟用
+
+**響應式**
+- 桌面：左右並排
+- 手機：上下堆疊（系統在上，外掛在下）
+
+### 系統設定頁面 (`/admin/settings`)
+
+**連線設定**
+- API 位址（若由 config.json 鎖定則顯示為唯讀）
+- 測試連線按鈕
+
+**介面設定**
+- 自動刷新間隔（下拉選單）
+- 啟用桌面通知（checkbox）
+
+**Kanboard 設定（暫時保留）**
+- 淡色/虛線框區塊
+- 說明文字：此區域將顯示可透過 KanproBridge 讀取/修改的伺服器設定
+
+**儲存位置**
+- 連線設定、介面設定 → localStorage
+- 未來 Kanboard 設定 → KanproBridge API
+
+### 使用者管理頁面 (`/admin/users`)
+
+整合現有 `UsersManagementView.vue`，移除獨立頁面的 header 元素。
+
+### 群組管理頁面 (`/admin/groups`)
+
+整合現有 `GroupsManagementView.vue`，移除獨立頁面的 header 元素。
+
+## 權限控制
+
+### UserDropdown
+```typescript
+const isAdmin = computed(() => authStore.user?.role === 'app-admin')
+```
+
+### 路由守衛
+```typescript
+router.beforeEach((to, from, next) => {
+  if (to.meta.requiresAdmin) {
+    const authStore = useAuthStore()
+    if (authStore.user?.role !== 'app-admin') {
+      return next({ name: 'all-tasks' })
+    }
+  }
+  next()
+})
+```
+
+## 檔案變更清單
+
+### 新增
+- `src/views/AdminStatusView.vue` - 系統狀態頁面
+- `src/views/AdminSettingsView.vue` - 系統設定頁面
+- `src/stores/system.ts` - 系統狀態 store
+
+### 修改
+- `src/services/api/jwt.ts` - API 方法更名
+- `src/stores/auth.ts` - 對應 API 更名
+- `src/router/index.ts` - 新增 admin 路由與守衛
+- `src/components/header/AppHeader.vue` - 新增 admin 導航
+- `src/components/header/UserDropdown.vue` - 新增系統管理選項
+- `src/views/UsersManagementView.vue` - 移除獨立 header
+- `src/views/GroupsManagementView.vue` - 移除獨立 header
+
+## KanproBridge API 對應
+
+| 模組 | API 方法 | Kanpro 功能 |
+|------|----------|-------------|
+| 核心 | `getKanproBridgeStatus` | 外掛狀態檢查 |
+| JWT | `getJWTToken`, `refreshJWTToken`, `revokeJWTToken` | 登入、Session 管理 |
+| 頭像 | `uploadUserAvatar`, `getUserAvatar`, `removeUserAvatar` | 個人頭像 |
+| 元資料 | `getUserMetadata`, `saveUserMetadata`, `removeUserMetadata` | 偏好設定 |
+| 密碼 | `changeUserPassword`, `resetUserPassword` | 密碼變更 |
+| 設定檔 | `getUserProfile`, `updateUserProfile` | 個人資料編輯 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "lucide-vue-next": "^0.562.0",
         "pinia": "^2.3.0",
         "vue": "^3.5.13",
-        "vue-router": "^4.5.0"
+        "vue-router": "^4.5.0",
+        "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
@@ -3050,6 +3051,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3538,6 +3545,18 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lucide-vue-next": "^0.562.0",
     "pinia": "^2.3.0",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",

--- a/src/__tests__/dashboard-store.test.ts
+++ b/src/__tests__/dashboard-store.test.ts
@@ -2,11 +2,33 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useDashboardStore } from '@/stores/dashboard'
 import { useAuthStore } from '@/stores/auth'
-import type { Task } from '@/types'
+import { useProjectsStore } from '@/stores/projects'
+import type { Task, Project } from '@/types'
 
 const mockFetch = vi.fn()
 
-const mockMyTasks: Task[] = [
+const mockProjects: Project[] = [
+  {
+    id: 1,
+    name: 'Project 1',
+    description: 'Description 1',
+    is_active: true,
+    is_public: false,
+    is_private: true,
+    owner_id: 1
+  },
+  {
+    id: 2,
+    name: 'Project 2',
+    description: 'Description 2',
+    is_active: true,
+    is_public: false,
+    is_private: true,
+    owner_id: 1
+  }
+]
+
+const mockMyTasksProject1: Task[] = [
   {
     id: 1,
     title: '我的任務一',
@@ -22,7 +44,10 @@ const mockMyTasks: Task[] = [
     creator_id: 1,
     date_creation: 1704067200,
     date_modification: 1704067200
-  },
+  }
+]
+
+const mockMyTasksProject2: Task[] = [
   {
     id: 2,
     title: '我的任務二',
@@ -41,7 +66,7 @@ const mockMyTasks: Task[] = [
   }
 ]
 
-const mockOverdueTasks: Task[] = [
+const mockOverdueTasksProject1: Task[] = [
   {
     id: 3,
     title: '逾期任務',
@@ -69,9 +94,11 @@ describe('Dashboard Store', () => {
 
     // Setup auth store with credentials
     const authStore = useAuthStore()
-    authStore._setTestCredentials({ apiUrl: 'http://localhost/jsonrpc.php',
-    username: 'admin',
-    password: 'admin' })
+    authStore._setTestCredentials({
+      apiUrl: 'http://localhost/jsonrpc.php',
+      username: 'admin',
+      password: 'admin'
+    })
   })
 
   afterEach(() => {
@@ -90,57 +117,160 @@ describe('Dashboard Store', () => {
   })
 
   describe('fetchMyTasks', () => {
-    it('should fetch and store my tasks', async () => {
+    it('should fetch and store my tasks from all projects', async () => {
+      // Mock getMyProjects
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
           jsonrpc: '2.0',
           id: 1,
-          result: mockMyTasks
+          result: mockProjects
+        })
+      })
+      // Mock searchTasks for project 1
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 2,
+          result: mockMyTasksProject1
+        })
+      })
+      // Mock searchTasks for project 2
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 3,
+          result: mockMyTasksProject2
         })
       })
 
       const store = useDashboardStore()
       await store.fetchMyTasks()
 
-      expect(store.myTasks).toEqual(mockMyTasks)
+      expect(store.myTasks).toHaveLength(2)
+      expect(store.myTasks).toContainEqual(expect.objectContaining({ id: 1 }))
+      expect(store.myTasks).toContainEqual(expect.objectContaining({ id: 2 }))
       expect(store.isLoading).toBe(false)
     })
 
-    it('should handle fetch error', async () => {
+    it('should handle fetch error when projects fetch fails', async () => {
+      // projectsStore.fetchProjects 會捕捉錯誤，所以 dashboard 會得到空專案列表
+      // 這導致沒有任務被載入，但不會設定 error（因為錯誤被 projectsStore 處理了）
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
       const store = useDashboardStore()
       await store.fetchMyTasks()
 
+      // 空專案列表 = 沒有任務
       expect(store.myTasks).toEqual([])
-      expect(store.error).toBe('Network error')
+      // error 不會被設定，因為 projectsStore 捕捉了錯誤
+      expect(store.error).toBeNull()
     })
-  })
 
-  describe('fetchOverdueTasks', () => {
-    it('should fetch and store overdue tasks', async () => {
+    it('should use cached projects if already loaded', async () => {
+      // Pre-load projects
+      const projectsStore = useProjectsStore()
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
           jsonrpc: '2.0',
           id: 1,
-          result: mockOverdueTasks
+          result: mockProjects
+        })
+      })
+      await projectsStore.fetchProjects()
+
+      // Mock searchTasks for project 1
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 2,
+          result: mockMyTasksProject1
+        })
+      })
+      // Mock searchTasks for project 2
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 3,
+          result: mockMyTasksProject2
+        })
+      })
+
+      const store = useDashboardStore()
+      await store.fetchMyTasks()
+
+      // Should not call getMyProjects again (only 3 calls total)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      expect(store.myTasks).toHaveLength(2)
+    })
+  })
+
+  describe('fetchOverdueTasks', () => {
+    it('should fetch and store overdue tasks from all projects', async () => {
+      // Mock getMyProjects
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockProjects
+        })
+      })
+      // Mock searchTasks for project 1 (overdue)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 2,
+          result: mockOverdueTasksProject1
+        })
+      })
+      // Mock searchTasks for project 2 (no overdue)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 3,
+          result: []
         })
       })
 
       const store = useDashboardStore()
       await store.fetchOverdueTasks()
 
-      expect(store.overdueTasks).toEqual(mockOverdueTasks)
+      expect(store.overdueTasks).toHaveLength(1)
+      expect(store.overdueTasks[0].id).toBe(3)
     })
 
     it('should handle empty overdue tasks', async () => {
+      // Mock getMyProjects
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
           jsonrpc: '2.0',
           id: 1,
+          result: mockProjects
+        })
+      })
+      // Mock searchTasks for both projects (no overdue)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 2,
+          result: []
+        })
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 3,
           result: []
         })
       })
@@ -154,41 +284,90 @@ describe('Dashboard Store', () => {
 
   describe('fetchDashboardData', () => {
     it('should fetch all dashboard data', async () => {
-      // Mock for searchTasks (my tasks)
+      // Pre-load projects to simplify mocking
+      const projectsStore = useProjectsStore()
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
           jsonrpc: '2.0',
           id: 1,
-          result: mockMyTasks
+          result: mockProjects
         })
       })
-      // Mock for getOverdueTasks
+      await projectsStore.fetchProjects()
+
+      // Mock searchTasks for myTasks (2 projects)
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
           jsonrpc: '2.0',
           id: 2,
-          result: mockOverdueTasks
+          result: mockMyTasksProject1
+        })
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 3,
+          result: mockMyTasksProject2
+        })
+      })
+      // Mock searchTasks for overdueTasks (2 projects)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 4,
+          result: mockOverdueTasksProject1
+        })
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 5,
+          result: []
         })
       })
 
       const store = useDashboardStore()
       await store.fetchDashboardData()
 
-      expect(store.myTasks).toEqual(mockMyTasks)
-      expect(store.overdueTasks).toEqual(mockOverdueTasks)
+      expect(store.myTasks).toHaveLength(2)
+      expect(store.overdueTasks).toHaveLength(1)
     })
   })
 
   describe('hasOverdueTasks', () => {
     it('should return true when there are overdue tasks', async () => {
+      // Pre-load projects
+      const projectsStore = useProjectsStore()
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
           jsonrpc: '2.0',
           id: 1,
-          result: mockOverdueTasks
+          result: mockProjects
+        })
+      })
+      await projectsStore.fetchProjects()
+
+      // Mock searchTasks for overdueTasks
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 2,
+          result: mockOverdueTasksProject1
+        })
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 3,
+          result: []
         })
       })
 
@@ -201,6 +380,23 @@ describe('Dashboard Store', () => {
     it('should return false when there are no overdue tasks', () => {
       const store = useDashboardStore()
       expect(store.hasOverdueTasks).toBe(false)
+    })
+  })
+
+  describe('clearDashboard', () => {
+    it('should clear all dashboard data', async () => {
+      const store = useDashboardStore()
+
+      // Manually set some data
+      store.myTasks.push(...mockMyTasksProject1)
+      store.overdueTasks.push(...mockOverdueTasksProject1)
+      store.error = 'Some error'
+
+      store.clearDashboard()
+
+      expect(store.myTasks).toEqual([])
+      expect(store.overdueTasks).toEqual([])
+      expect(store.error).toBeNull()
     })
   })
 })

--- a/src/__tests__/groups-store.test.ts
+++ b/src/__tests__/groups-store.test.ts
@@ -88,14 +88,16 @@ describe('Groups Store', () => {
       expect(store.isLoading).toBe(false)
     })
 
-    it('should handle fetch error', async () => {
+    it('should handle fetch error silently (admin API)', async () => {
+      // getAllGroups 需要 admin 權限，非 admin 用戶會靜默失敗
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
       const store = useGroupsStore()
       await store.fetchAllGroups()
 
+      // 靜默失敗：groups 清空，不設定 error
       expect(store.groups).toEqual([])
-      expect(store.error).toBe('Network error')
+      expect(store.error).toBeNull()
     })
 
     it('should call API with correct method', async () => {

--- a/src/__tests__/jwt-service.test.ts
+++ b/src/__tests__/jwt-service.test.ts
@@ -71,7 +71,7 @@ describe('JWTAuthService', () => {
       })
       const body = JSON.parse(options?.body as string)
       expect(body.jsonrpc).toBe('2.0')
-      expect(body.method).toBe('getKanproBridgePlugin')
+      expect(body.method).toBe('getKanproBridgeStatus')
       expect(typeof body.id).toBe('number')
     })
 

--- a/src/__tests__/system-store.test.ts
+++ b/src/__tests__/system-store.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useSystemStore, BRIDGE_MODULES } from '@/stores/system'
+import { useAuthStore } from '@/stores/auth'
+
+// Mock fetch for API calls
+const mockFetch = vi.fn()
+
+describe('System Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.stubGlobal('fetch', mockFetch)
+    mockFetch.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('initial state', () => {
+    it('should have null values initially', () => {
+      const store = useSystemStore()
+
+      expect(store.kanboardVersion).toBeNull()
+      expect(store.kanboardTimezone).toBeNull()
+      expect(store.apiLatency).toBeNull()
+      expect(store.connectionStatus).toBe('checking')
+      expect(store.bridgeStatus).toBeNull()
+      expect(store.bridgeError).toBeNull()
+      expect(store.isLoading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+  })
+
+  describe('BRIDGE_MODULES', () => {
+    it('should define JWT module', () => {
+      const jwtModule = BRIDGE_MODULES.find(m => m.id === 'jwt')
+      expect(jwtModule).toBeDefined()
+      expect(jwtModule?.name).toBe('JWT 認證')
+      expect(jwtModule?.methods).toContain('getJWTToken')
+    })
+
+    it('should define avatar module', () => {
+      const avatarModule = BRIDGE_MODULES.find(m => m.id === 'avatar')
+      expect(avatarModule).toBeDefined()
+      expect(avatarModule?.name).toBe('使用者頭像')
+      expect(avatarModule?.methods).toContain('uploadUserAvatar')
+    })
+
+    it('should define metadata module', () => {
+      const metadataModule = BRIDGE_MODULES.find(m => m.id === 'metadata')
+      expect(metadataModule).toBeDefined()
+      expect(metadataModule?.name).toBe('使用者元資料')
+      expect(metadataModule?.methods).toContain('getUserMetadata')
+    })
+
+    it('should define password module', () => {
+      const passwordModule = BRIDGE_MODULES.find(m => m.id === 'password')
+      expect(passwordModule).toBeDefined()
+      expect(passwordModule?.name).toBe('密碼管理')
+      expect(passwordModule?.methods).toContain('changeUserPassword')
+    })
+
+    it('should define profile module', () => {
+      const profileModule = BRIDGE_MODULES.find(m => m.id === 'profile')
+      expect(profileModule).toBeDefined()
+      expect(profileModule?.name).toBe('使用者設定檔')
+      expect(profileModule?.methods).toContain('getUserProfile')
+    })
+  })
+
+  describe('isModuleEnabled', () => {
+    it('should return false when bridgeStatus is null', () => {
+      const store = useSystemStore()
+      expect(store.isModuleEnabled('jwt')).toBe(false)
+    })
+
+    it('should return true when all module methods are available', () => {
+      const store = useSystemStore()
+      store.bridgeStatus = {
+        name: 'KanproBridge',
+        version: '1.0.0',
+        methods: ['getJWTToken', 'refreshJWTToken', 'revokeJWTToken']
+      }
+      expect(store.isModuleEnabled('jwt')).toBe(true)
+    })
+
+    it('should return false when some module methods are missing', () => {
+      const store = useSystemStore()
+      store.bridgeStatus = {
+        name: 'KanproBridge',
+        version: '1.0.0',
+        methods: ['getJWTToken'] // missing refreshJWTToken, revokeJWTToken
+      }
+      expect(store.isModuleEnabled('jwt')).toBe(false)
+    })
+
+    it('should return false for unknown module', () => {
+      const store = useSystemStore()
+      store.bridgeStatus = {
+        name: 'KanproBridge',
+        version: '1.0.0',
+        methods: []
+      }
+      expect(store.isModuleEnabled('unknown')).toBe(false)
+    })
+  })
+
+  describe('moduleStatuses', () => {
+    it('should return all modules with enabled status', () => {
+      const store = useSystemStore()
+      store.bridgeStatus = {
+        name: 'KanproBridge',
+        version: '1.0.0',
+        methods: [
+          'getJWTToken', 'refreshJWTToken', 'revokeJWTToken',
+          'uploadUserAvatar', 'getUserAvatar', 'removeUserAvatar'
+        ]
+      }
+
+      const statuses = store.moduleStatuses
+      expect(statuses.length).toBe(BRIDGE_MODULES.length)
+
+      const jwtStatus = statuses.find(s => s.id === 'jwt')
+      expect(jwtStatus?.enabled).toBe(true)
+
+      const avatarStatus = statuses.find(s => s.id === 'avatar')
+      expect(avatarStatus?.enabled).toBe(true)
+
+      const metadataStatus = statuses.find(s => s.id === 'metadata')
+      expect(metadataStatus?.enabled).toBe(false) // methods not available
+    })
+  })
+
+  describe('fetchKanboardInfo', () => {
+    it('should fetch version and timezone successfully', async () => {
+      // Setup auth store
+      const authStore = useAuthStore()
+      authStore._setTestCredentials({
+        apiUrl: 'https://test.com/jsonrpc.php',
+        username: 'admin',
+        accessToken: 'test-token'
+      })
+
+      // Mock getVersion
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: '1.2.30'
+        })
+      })
+
+      // Mock getTimezone
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 2,
+          result: 'Asia/Taipei'
+        })
+      })
+
+      const store = useSystemStore()
+      await store.fetchKanboardInfo()
+
+      expect(store.kanboardVersion).toBe('1.2.30')
+      expect(store.kanboardTimezone).toBe('Asia/Taipei')
+      expect(store.connectionStatus).toBe('connected')
+      expect(store.apiLatency).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should handle connection error', async () => {
+      // Setup auth store
+      const authStore = useAuthStore()
+      authStore._setTestCredentials({
+        apiUrl: 'https://test.com/jsonrpc.php',
+        username: 'admin',
+        accessToken: 'test-token'
+      })
+
+      // Mock failed request
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const store = useSystemStore()
+      await store.fetchKanboardInfo()
+
+      expect(store.connectionStatus).toBe('disconnected')
+      expect(store.error).toContain('Network error')
+    })
+  })
+
+  describe('fetchBridgeStatus', () => {
+    it('should fetch bridge status successfully', async () => {
+      // Setup auth store
+      const authStore = useAuthStore()
+      authStore._setTestCredentials({
+        apiUrl: 'https://test.com/jsonrpc.php',
+        username: 'admin',
+        accessToken: 'test-token'
+      })
+
+      const mockBridgeStatus = {
+        name: 'KanproBridge',
+        version: '1.0.0',
+        description: 'Kanpro Bridge Plugin',
+        methods: ['getJWTToken', 'refreshJWTToken', 'revokeJWTToken']
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: mockBridgeStatus
+        })
+      })
+
+      const store = useSystemStore()
+      await store.fetchBridgeStatus()
+
+      expect(store.bridgeStatus).toEqual(mockBridgeStatus)
+      expect(store.bridgeError).toBeNull()
+    })
+
+    it('should handle bridge status error', async () => {
+      // Setup auth store
+      const authStore = useAuthStore()
+      authStore._setTestCredentials({
+        apiUrl: 'https://test.com/jsonrpc.php',
+        username: 'admin',
+        accessToken: 'test-token'
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          error: { code: -32601, message: 'Method not found' }
+        })
+      })
+
+      const store = useSystemStore()
+      await store.fetchBridgeStatus()
+
+      expect(store.bridgeStatus).toBeNull()
+      expect(store.bridgeError).toContain('Method not found')
+    })
+  })
+
+  describe('testConnection', () => {
+    it('should return success with latency', async () => {
+      // Setup auth store
+      const authStore = useAuthStore()
+      authStore._setTestCredentials({
+        apiUrl: 'https://test.com/jsonrpc.php',
+        username: 'admin',
+        accessToken: 'test-token'
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: '1.2.30'
+        })
+      })
+
+      const store = useSystemStore()
+      const result = await store.testConnection()
+
+      expect(result.success).toBe(true)
+      expect(result.latency).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should return failure on error', async () => {
+      // Setup auth store
+      const authStore = useAuthStore()
+      authStore._setTestCredentials({
+        apiUrl: 'https://test.com/jsonrpc.php',
+        username: 'admin',
+        accessToken: 'test-token'
+      })
+
+      mockFetch.mockRejectedValueOnce(new Error('Connection refused'))
+
+      const store = useSystemStore()
+      const result = await store.testConnection()
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Connection refused')
+    })
+  })
+
+  describe('$reset', () => {
+    it('should reset all state to initial values', () => {
+      const store = useSystemStore()
+
+      // Set some values
+      store.kanboardVersion = '1.2.30'
+      store.kanboardTimezone = 'Asia/Taipei'
+      store.apiLatency = 50
+      store.connectionStatus = 'connected'
+      store.bridgeStatus = { name: 'test', version: '1.0', methods: [] }
+      store.bridgeError = 'some error'
+      store.isLoading = true
+      store.error = 'another error'
+
+      // Reset
+      store.$reset()
+
+      // Verify reset
+      expect(store.kanboardVersion).toBeNull()
+      expect(store.kanboardTimezone).toBeNull()
+      expect(store.apiLatency).toBeNull()
+      expect(store.connectionStatus).toBe('checking')
+      expect(store.bridgeStatus).toBeNull()
+      expect(store.bridgeError).toBeNull()
+      expect(store.isLoading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+  })
+})

--- a/src/__tests__/system-store.test.ts
+++ b/src/__tests__/system-store.test.ts
@@ -37,35 +37,35 @@ describe('System Store', () => {
       const jwtModule = BRIDGE_MODULES.find(m => m.id === 'jwt')
       expect(jwtModule).toBeDefined()
       expect(jwtModule?.name).toBe('JWT 認證')
-      expect(jwtModule?.methods).toContain('getJWTToken')
+      expect(jwtModule?.featureKey).toBe('jwt_auth')
     })
 
     it('should define avatar module', () => {
       const avatarModule = BRIDGE_MODULES.find(m => m.id === 'avatar')
       expect(avatarModule).toBeDefined()
       expect(avatarModule?.name).toBe('使用者頭像')
-      expect(avatarModule?.methods).toContain('uploadUserAvatar')
+      expect(avatarModule?.featureKey).toBe('user_avatar')
     })
 
     it('should define metadata module', () => {
       const metadataModule = BRIDGE_MODULES.find(m => m.id === 'metadata')
       expect(metadataModule).toBeDefined()
       expect(metadataModule?.name).toBe('使用者元資料')
-      expect(metadataModule?.methods).toContain('getUserMetadata')
+      expect(metadataModule?.featureKey).toBe('user_metadata')
     })
 
     it('should define password module', () => {
       const passwordModule = BRIDGE_MODULES.find(m => m.id === 'password')
       expect(passwordModule).toBeDefined()
       expect(passwordModule?.name).toBe('密碼管理')
-      expect(passwordModule?.methods).toContain('changeUserPassword')
+      expect(passwordModule?.featureKey).toBe('user_password')
     })
 
     it('should define profile module', () => {
       const profileModule = BRIDGE_MODULES.find(m => m.id === 'profile')
       expect(profileModule).toBeDefined()
       expect(profileModule?.name).toBe('使用者設定檔')
-      expect(profileModule?.methods).toContain('getUserProfile')
+      expect(profileModule?.featureKey).toBe('user_profile')
     })
   })
 
@@ -75,22 +75,34 @@ describe('System Store', () => {
       expect(store.isModuleEnabled('jwt')).toBe(false)
     })
 
-    it('should return true when all module methods are available', () => {
+    it('should return true when feature is enabled', () => {
       const store = useSystemStore()
       store.bridgeStatus = {
         name: 'KanproBridge',
         version: '1.0.0',
-        methods: ['getJWTToken', 'refreshJWTToken', 'revokeJWTToken']
+        features: {
+          jwt_auth: { enabled: true, methods: [] },
+          user_metadata: { enabled: false, methods: [] },
+          user_avatar: { enabled: false, methods: [] },
+          user_password: { enabled: false, methods: [] },
+          user_profile: { enabled: false, methods: [] }
+        }
       }
       expect(store.isModuleEnabled('jwt')).toBe(true)
     })
 
-    it('should return false when some module methods are missing', () => {
+    it('should return false when feature is disabled', () => {
       const store = useSystemStore()
       store.bridgeStatus = {
         name: 'KanproBridge',
         version: '1.0.0',
-        methods: ['getJWTToken'] // missing refreshJWTToken, revokeJWTToken
+        features: {
+          jwt_auth: { enabled: false, methods: [] },
+          user_metadata: { enabled: false, methods: [] },
+          user_avatar: { enabled: false, methods: [] },
+          user_password: { enabled: false, methods: [] },
+          user_profile: { enabled: false, methods: [] }
+        }
       }
       expect(store.isModuleEnabled('jwt')).toBe(false)
     })
@@ -100,7 +112,13 @@ describe('System Store', () => {
       store.bridgeStatus = {
         name: 'KanproBridge',
         version: '1.0.0',
-        methods: []
+        features: {
+          jwt_auth: { enabled: true, methods: [] },
+          user_metadata: { enabled: true, methods: [] },
+          user_avatar: { enabled: true, methods: [] },
+          user_password: { enabled: true, methods: [] },
+          user_profile: { enabled: true, methods: [] }
+        }
       }
       expect(store.isModuleEnabled('unknown')).toBe(false)
     })
@@ -112,10 +130,13 @@ describe('System Store', () => {
       store.bridgeStatus = {
         name: 'KanproBridge',
         version: '1.0.0',
-        methods: [
-          'getJWTToken', 'refreshJWTToken', 'revokeJWTToken',
-          'uploadUserAvatar', 'getUserAvatar', 'removeUserAvatar'
-        ]
+        features: {
+          jwt_auth: { enabled: true, methods: [] },
+          user_metadata: { enabled: false, methods: [] },
+          user_avatar: { enabled: true, methods: [] },
+          user_password: { enabled: true, methods: [] },
+          user_profile: { enabled: false, methods: [] }
+        }
       }
 
       const statuses = store.moduleStatuses
@@ -128,7 +149,7 @@ describe('System Store', () => {
       expect(avatarStatus?.enabled).toBe(true)
 
       const metadataStatus = statuses.find(s => s.id === 'metadata')
-      expect(metadataStatus?.enabled).toBe(false) // methods not available
+      expect(metadataStatus?.enabled).toBe(false)
     })
   })
 
@@ -205,7 +226,13 @@ describe('System Store', () => {
         name: 'KanproBridge',
         version: '1.0.0',
         description: 'Kanpro Bridge Plugin',
-        methods: ['getJWTToken', 'refreshJWTToken', 'revokeJWTToken']
+        features: {
+          jwt_auth: { enabled: true, methods: [] },
+          user_metadata: { enabled: true, methods: [] },
+          user_avatar: { enabled: true, methods: [] },
+          user_password: { enabled: true, methods: [] },
+          user_profile: { enabled: false, methods: [] }
+        }
       }
 
       mockFetch.mockResolvedValueOnce({
@@ -304,7 +331,17 @@ describe('System Store', () => {
       store.kanboardTimezone = 'Asia/Taipei'
       store.apiLatency = 50
       store.connectionStatus = 'connected'
-      store.bridgeStatus = { name: 'test', version: '1.0', methods: [] }
+      store.bridgeStatus = {
+        name: 'test',
+        version: '1.0',
+        features: {
+          jwt_auth: { enabled: true, methods: [] },
+          user_metadata: { enabled: true, methods: [] },
+          user_avatar: { enabled: true, methods: [] },
+          user_password: { enabled: true, methods: [] },
+          user_profile: { enabled: true, methods: [] }
+        }
+      }
       store.bridgeError = 'some error'
       store.isLoading = true
       store.error = 'another error'

--- a/src/__tests__/users-store.test.ts
+++ b/src/__tests__/users-store.test.ts
@@ -78,14 +78,16 @@ describe('Users Store', () => {
       expect(store.isLoading).toBe(false)
     })
 
-    it('should handle fetch error', async () => {
+    it('should handle fetch error silently (admin API)', async () => {
+      // getAllUsers 需要 admin 權限，非 admin 用戶會靜默失敗
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
       const store = useUsersStore()
       await store.fetchAllUsers()
 
+      // 靜默失敗：users 清空，不設定 error
       expect(store.users).toEqual([])
-      expect(store.error).toBe('Network error')
+      expect(store.error).toBeNull()
     })
 
     it('should call API with correct method', async () => {

--- a/src/components/NotificationsDropdown.vue
+++ b/src/components/NotificationsDropdown.vue
@@ -10,6 +10,69 @@ const notificationsStore = useNotificationsStore()
 const isOpen = ref(false)
 let pollInterval: ReturnType<typeof setInterval> | null = null
 
+// Settings Storage Key (與 AdminSettingsView 相同)
+const SETTINGS_KEY = 'kanpro_settings'
+
+// 讀取通知檢查間隔設定
+function getNotificationCheckInterval(): number {
+  try {
+    const saved = localStorage.getItem(SETTINGS_KEY)
+    if (saved) {
+      const settings = JSON.parse(saved)
+      return settings.notificationCheckInterval ?? 300
+    }
+  } catch {
+    // 使用預設值
+  }
+  return 300 // 預設 5 分鐘
+}
+
+// 檢查桌面通知是否啟用
+function isDesktopNotificationsEnabled(): boolean {
+  try {
+    const saved = localStorage.getItem(SETTINGS_KEY)
+    if (saved) {
+      const settings = JSON.parse(saved)
+      return settings.enableDesktopNotifications ?? false
+    }
+  } catch {
+    // 使用預設值
+  }
+  return false
+}
+
+// 發送桌面通知
+function sendDesktopNotification(activity: Activity): void {
+  if (!('Notification' in window)) return
+  if (Notification.permission !== 'granted') return
+  if (!isDesktopNotificationsEnabled()) return
+
+  const title = getEventLabel(activity.event_name)
+  const taskTitle = getTaskTitle(activity)
+  const body = taskTitle ? `${taskTitle}` : '您有新的通知'
+
+  const notification = new Notification(title, {
+    body,
+    icon: '/favicon.ico',
+    tag: `kanpro-${activity.id}` // 避免重複通知
+  })
+
+  notification.onclick = () => {
+    window.focus()
+    if (activity.task_id && activity.project_id) {
+      router.push({
+        name: 'board',
+        params: { projectId: activity.project_id },
+        query: { task: activity.task_id.toString() }
+      })
+    }
+    notification.close()
+  }
+}
+
+// 追蹤已處理過的活動 ID（避免重複發送桌面通知）
+const processedActivityIds = new Set<number>()
+
 const eventLabels: Record<string, string> = {
   'task.create': '建立任務',
   'task.update': '更新任務',
@@ -82,16 +145,57 @@ const handleMarkAllAsRead = () => {
   notificationsStore.markAllAsRead()
 }
 
+// 檢查並發送新通知的桌面通知
+async function checkAndNotify(): Promise<void> {
+  const previousIds = new Set(notificationsStore.activities.map(a => a.id))
+  await notificationsStore.fetchActivities()
+
+  // 找出新的未讀活動並發送桌面通知
+  for (const activity of notificationsStore.activities) {
+    if (
+      !previousIds.has(activity.id) &&
+      !notificationsStore.isRead(activity.id) &&
+      !processedActivityIds.has(activity.id)
+    ) {
+      processedActivityIds.add(activity.id)
+      sendDesktopNotification(activity)
+    }
+  }
+
+  // 清理過舊的 processedActivityIds（保留最近 1000 筆）
+  if (processedActivityIds.size > 1000) {
+    const idsToKeep = notificationsStore.activities.map(a => a.id)
+    processedActivityIds.clear()
+    idsToKeep.forEach(id => processedActivityIds.add(id))
+  }
+}
+
 const startPolling = () => {
+  stopPolling() // 先停止現有輪詢
+
+  const intervalSeconds = getNotificationCheckInterval()
+  if (intervalSeconds === 0) return // 停用輪詢
+
+  const intervalMs = intervalSeconds * 1000
+
+  // 通知檢查在背景分頁也持續運作（不受 page visibility 影響）
   pollInterval = setInterval(() => {
-    notificationsStore.fetchActivities()
-  }, 60000) // 60 seconds
+    checkAndNotify()
+  }, intervalMs)
 }
 
 const stopPolling = () => {
   if (pollInterval) {
     clearInterval(pollInterval)
     pollInterval = null
+  }
+}
+
+// 監聽設定變更（透過 storage 事件）
+const handleStorageChange = (event: StorageEvent) => {
+  if (event.key === SETTINGS_KEY) {
+    // 設定變更時重新啟動輪詢
+    startPolling()
   }
 }
 
@@ -106,13 +210,19 @@ const handleClickOutside = (event: MouseEvent) => {
 onMounted(async () => {
   notificationsStore.loadReadIds()
   await notificationsStore.fetchActivities()
+
+  // 初始化已處理活動 ID（避免首次載入時發送舊通知）
+  notificationsStore.activities.forEach(a => processedActivityIds.add(a.id))
+
   startPolling()
   document.addEventListener('click', handleClickOutside)
+  window.addEventListener('storage', handleStorageChange)
 })
 
 onUnmounted(() => {
   stopPolling()
   document.removeEventListener('click', handleClickOutside)
+  window.removeEventListener('storage', handleStorageChange)
 })
 
 watch(() => isOpen.value, (open) => {

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -9,7 +9,12 @@ function getIcon(type: ToastType): string {
     case 'error': return 'x-circle'
     case 'warning': return 'warning'
     case 'info': return 'info'
+    case 'loading': return 'spinner'
   }
+}
+
+function isLoading(type: ToastType): boolean {
+  return type === 'loading'
 }
 
 function getClasses(type: ToastType): string {
@@ -18,6 +23,7 @@ function getClasses(type: ToastType): string {
     case 'error': return 'bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200'
     case 'warning': return 'bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200'
     case 'info': return 'bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-200'
+    case 'loading': return 'bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200'
   }
 }
 </script>
@@ -43,7 +49,10 @@ function getClasses(type: ToastType): string {
             getClasses(toast.type)
           ]"
         >
-          <ph-icon :icon="getIcon(toast.type)" class="w-5 h-5 flex-shrink-0 mt-0.5" />
+          <ph-icon
+            :icon="getIcon(toast.type)"
+            :class="['w-5 h-5 flex-shrink-0 mt-0.5', isLoading(toast.type) && 'animate-spin']"
+          />
           <div class="flex-1 min-w-0">
             <p class="text-sm font-semibold">{{ toast.title }}</p>
             <p v-if="toast.message" class="text-sm opacity-80 mt-0.5">{{ toast.message }}</p>

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -13,18 +13,21 @@ function getIcon(type: ToastType): string {
   }
 }
 
-function isLoading(type: ToastType): boolean {
-  return type === 'loading'
-}
-
 function getClasses(type: ToastType): string {
   switch (type) {
     case 'success': return 'bg-emerald-50 dark:bg-emerald-950 border border-emerald-200 dark:border-emerald-800 text-emerald-800 dark:text-emerald-200'
     case 'error': return 'bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200'
     case 'warning': return 'bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200'
     case 'info': return 'bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-200'
-    case 'loading': return 'bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200'
+    case 'loading': return 'bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-400 dark:text-slate-500'
   }
+}
+
+function getIconClasses(type: ToastType): string {
+  if (type === 'loading') {
+    return 'text-slate-600 dark:text-slate-300 animate-spin'
+  }
+  return ''
 }
 </script>
 
@@ -44,14 +47,14 @@ function getClasses(type: ToastType): string {
           v-for="toast in toastStore.toasts"
           :key="toast.id"
           :class="[
-            'pointer-events-auto flex gap-3 px-4 py-3 rounded-lg shadow-lg max-w-sm',
+            'pointer-events-auto flex gap-3 px-4 py-3 rounded-lg shadow-lg max-w-sm transition-colors duration-300',
             toast.message ? 'items-start' : 'items-center',
             getClasses(toast.type)
           ]"
         >
           <ph-icon
             :icon="getIcon(toast.type)"
-            :class="['w-5 h-5 flex-shrink-0 mt-0.5', isLoading(toast.type) && 'animate-spin']"
+            :class="['w-5 h-5 flex-shrink-0 mt-0.5 transition-colors duration-300', getIconClasses(toast.type)]"
           />
           <div class="flex-1 min-w-0">
             <p class="text-sm font-semibold">{{ toast.title }}</p>

--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -20,6 +20,9 @@ const boardStore = useBoardStore()
 const currentProjectId = computed(() => sidebarStore.currentProjectId)
 const currentProjectName = computed(() => boardStore.project?.name || '')
 
+// Check if we're in admin context
+const isAdminContext = computed(() => route.path.startsWith('/admin'))
+
 const projectNavItems = computed(() => {
   const id = currentProjectId.value
   if (!id) return []
@@ -33,6 +36,14 @@ const projectNavItems = computed(() => {
     { name: 'project-settings', label: '設定', icon: 'gear', route: `/projects/${id}/settings` }
   ]
 })
+
+// Admin navigation items
+const adminNavItems = [
+  { name: 'admin-status', label: '系統狀態', icon: 'pulse', route: '/admin' },
+  { name: 'admin-settings', label: '系統設定', icon: 'gear', route: '/admin/settings' },
+  { name: 'admin-users', label: '使用者管理', icon: 'users', route: '/admin/users' },
+  { name: 'admin-groups', label: '群組管理', icon: 'users-three', route: '/admin/groups' }
+]
 
 function isActiveRoute(routeName: string): boolean {
   return route.name === routeName
@@ -71,8 +82,8 @@ function openCreateTask(): void {
 
     <!-- Left side content -->
     <div class="hidden lg:flex items-center gap-1">
-      <!-- Quick Actions (Left side - only when NOT in project context) -->
-      <template v-if="!currentProjectId">
+      <!-- Quick Actions (Left side - only when NOT in project or admin context) -->
+      <template v-if="!currentProjectId && !isAdminContext">
         <!-- Create Project Button -->
         <button
           @click="openCreateProject"
@@ -103,7 +114,7 @@ function openCreateTask(): void {
       </template>
 
       <!-- Project Navigation (when in project context) - Style B -->
-      <template v-if="currentProjectId">
+      <template v-if="currentProjectId && !isAdminContext">
         <!-- Project Name with Icon Box -->
         <div class="flex items-center gap-2 min-w-0">
           <div class="w-7 h-7 bg-accent/10 rounded-md flex items-center justify-center flex-shrink-0">
@@ -140,6 +151,59 @@ function openCreateTask(): void {
         <div class="hidden lg:flex xl:hidden items-center gap-1">
           <button
             v-for="item in projectNavItems"
+            :key="item.name"
+            @click="navigateTo(item.route)"
+            :class="[
+              'p-2 rounded-md transition-colors',
+              isActiveRoute(item.name)
+                ? 'bg-accent text-content-inverse'
+                : 'text-content-tertiary hover:text-content-secondary hover:bg-surface-hover'
+            ]"
+            :title="item.label"
+          >
+            <ph-icon :icon="item.icon" class="w-4 h-4" />
+          </button>
+        </div>
+      </template>
+
+      <!-- Admin Navigation (when in admin context) -->
+      <template v-if="isAdminContext">
+        <!-- Admin Title with Icon Box -->
+        <div class="flex items-center gap-2 min-w-0">
+          <div class="w-7 h-7 bg-error/10 rounded-md flex items-center justify-center flex-shrink-0">
+            <ph-icon icon="gear-six" class="w-4 h-4 text-error" />
+          </div>
+          <span class="text-base font-semibold text-content">
+            系統管理
+          </span>
+        </div>
+
+        <!-- Chevron Separator -->
+        <ph-icon icon="caret-right" class="w-4 h-4 text-content-tertiary ml-1 flex-shrink-0" />
+
+        <!-- Full Navigation (xl and above) -->
+        <div class="hidden xl:flex items-center gap-1">
+          <button
+            v-for="item in adminNavItems"
+            :key="item.name"
+            @click="navigateTo(item.route)"
+            :class="[
+              'flex items-center gap-1.5 px-2.5 py-1.5 text-sm rounded-md transition-colors',
+              isActiveRoute(item.name)
+                ? 'bg-accent text-content-inverse'
+                : 'text-content-tertiary hover:text-content-secondary hover:bg-surface-hover'
+            ]"
+            :title="item.label"
+          >
+            <ph-icon :icon="item.icon" class="w-4 h-4" />
+            <span>{{ item.label }}</span>
+          </button>
+        </div>
+
+        <!-- Compact Navigation (lg to xl) - icons only with tooltips -->
+        <div class="hidden lg:flex xl:hidden items-center gap-1">
+          <button
+            v-for="item in adminNavItems"
             :key="item.name"
             @click="navigateTo(item.route)"
             :class="[

--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -168,18 +168,16 @@ function openCreateTask(): void {
 
       <!-- Admin Navigation (when in admin context) -->
       <template v-if="isAdminContext">
-        <!-- Admin Title with Icon Box -->
+        <!-- Admin Title -->
         <div class="flex items-center gap-2 min-w-0">
-          <div class="w-7 h-7 bg-error/10 rounded-md flex items-center justify-center flex-shrink-0">
-            <ph-icon icon="gear-six" class="w-4 h-4 text-error" />
-          </div>
+          <ph-icon icon="gear-six" class="w-5 h-5 text-content-secondary flex-shrink-0" />
           <span class="text-base font-semibold text-content">
             系統管理
           </span>
         </div>
 
-        <!-- Chevron Separator -->
-        <ph-icon icon="caret-right" class="w-4 h-4 text-content-tertiary ml-1 flex-shrink-0" />
+        <!-- Separator -->
+        <span class="text-content-tertiary mx-1">|</span>
 
         <!-- Full Navigation (xl and above) -->
         <div class="hidden xl:flex items-center gap-1">

--- a/src/components/header/UserDropdown.vue
+++ b/src/components/header/UserDropdown.vue
@@ -29,6 +29,9 @@ const avatarBgColor = computed(() => getAvatarColor(displayName.value))
 // 直接使用 store 的頭像資料（與其他元件同步）
 const avatarImageData = computed(() => authStore.avatarData)
 
+// 檢查是否為管理員
+const isAdmin = computed(() => authStore.user?.role === 'app-admin')
+
 // 當使用者變更時載入頭像
 watch(() => authStore.user?.id, (newId) => {
   if (newId && !authStore.avatarData && !authStore.avatarLoading) {
@@ -57,6 +60,11 @@ const handleLogout = async () => {
 const goToSettings = () => {
   closeDropdown()
   router.push('/settings')
+}
+
+const goToAdmin = () => {
+  closeDropdown()
+  router.push('/admin')
 }
 
 const toggleThemeMenu = () => {
@@ -160,6 +168,16 @@ onUnmounted(() => {
           >
             <ph-icon icon="user" class="w-4 h-4 text-content-secondary" />
             個人設定
+          </button>
+
+          <!-- System Management (Admin Only) -->
+          <button
+            v-if="isAdmin"
+            @click="goToAdmin"
+            class="w-full px-4 py-2 text-left text-sm text-content hover:bg-surface-hover transition-colors flex items-center gap-3"
+          >
+            <ph-icon icon="gear-six" class="w-4 h-4 text-content-secondary" />
+            系統管理
           </button>
 
           <!-- Theme Selector -->

--- a/src/plugins/phosphor.ts
+++ b/src/plugins/phosphor.ts
@@ -34,10 +34,12 @@ import {
   PhCalendarBlank,
   PhCalendar,
   PhGear,
+  PhGearSix,
   PhChartBar,
   PhFolder,
   PhFolderOpen,
   PhSquaresFour,
+  PhPulse,
 
   // 使用者相關
   PhUser,
@@ -154,10 +156,12 @@ export const iconComponents = {
   'calendar-blank': PhCalendarBlank,
   'calendar': PhCalendar,
   'gear': PhGear,
+  'gear-six': PhGearSix,
   'chart-bar': PhChartBar,
   'folder': PhFolder,
   'folder-open': PhFolderOpen,
   'squares-four': PhSquaresFour,
+  'pulse': PhPulse,
 
   // 使用者相關
   'user': PhUser,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -80,12 +80,12 @@ const router = createRouter({
             {
               path: 'users',
               name: 'admin-users',
-              component: () => import('@/views/UsersManagementView.vue')
+              component: () => import('@/views/AdminUsersView.vue')
             },
             {
               path: 'groups',
               name: 'admin-groups',
-              component: () => import('@/views/GroupsManagementView.vue')
+              component: () => import('@/views/AdminGroupsView.vue')
             }
           ]
         },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -61,17 +61,33 @@ const router = createRouter({
           component: () => import('@/views/UserSettingsView.vue'),
           meta: { sidebarMode: 'global' }
         },
+
+        // Admin views
         {
-          path: 'admin/users',
-          name: 'admin-users',
-          component: () => import('@/views/UsersManagementView.vue'),
-          meta: { sidebarMode: 'global' }
-        },
-        {
-          path: 'admin/groups',
-          name: 'admin-groups',
-          component: () => import('@/views/GroupsManagementView.vue'),
-          meta: { sidebarMode: 'global' }
+          path: 'admin',
+          meta: { sidebarMode: 'admin', requiresAdmin: true },
+          children: [
+            {
+              path: '',
+              name: 'admin-status',
+              component: () => import('@/views/AdminStatusView.vue')
+            },
+            {
+              path: 'settings',
+              name: 'admin-settings',
+              component: () => import('@/views/AdminSettingsView.vue')
+            },
+            {
+              path: 'users',
+              name: 'admin-users',
+              component: () => import('@/views/UsersManagementView.vue')
+            },
+            {
+              path: 'groups',
+              name: 'admin-groups',
+              component: () => import('@/views/GroupsManagementView.vue')
+            }
+          ]
         },
 
         // Project views - List is default
@@ -136,6 +152,13 @@ router.beforeEach(async (to, _from, next) => {
   // 如果已登入但訪問 guest 頁面（如登入頁），導向首頁
   if (to.meta.guest && authStore.isAuthenticated) {
     return next({ name: 'all-tasks' })
+  }
+
+  // 如果需要 admin 權限但不是 admin，導向首頁
+  if (to.matched.some(record => record.meta.requiresAdmin)) {
+    if (authStore.user?.role !== 'app-admin') {
+      return next({ name: 'all-tasks' })
+    }
   }
 
   next()

--- a/src/services/api/jwt.ts
+++ b/src/services/api/jwt.ts
@@ -118,7 +118,7 @@ export function createJWTAuthService(): JWTAuthService {
   return {
     async checkPlugin(apiUrl: string, username: string, password: string): Promise<JWTPluginInfo | null> {
       try {
-        return await call<JWTPluginInfo>(apiUrl, 'getKanproBridgePlugin', username, password)
+        return await call<JWTPluginInfo>(apiUrl, 'getKanproBridgeStatus', username, password)
       } catch (error) {
         if (error instanceof Error) {
           // HTTP 401 或 JSON-RPC error code 401：認證失敗

--- a/src/stores/board.ts
+++ b/src/stores/board.ts
@@ -37,10 +37,12 @@ export const useBoardStore = defineStore('board', () => {
     return swimlanes.value[0].columns
   })
 
-  async function fetchBoard(projectId: number): Promise<void> {
+  async function fetchBoard(projectId: number, silent = false): Promise<void> {
     const authStore = useAuthStore()
 
-    isLoading.value = true
+    if (!silent) {
+      isLoading.value = true
+    }
     error.value = null
 
     try {
@@ -62,7 +64,9 @@ export const useBoardStore = defineStore('board', () => {
       project.value = null
       swimlanes.value = []
     } finally {
-      isLoading.value = false
+      if (!silent) {
+        isLoading.value = false
+      }
     }
   }
 

--- a/src/stores/system.ts
+++ b/src/stores/system.ts
@@ -88,6 +88,7 @@ export const useSystemStore = defineStore('system', () => {
    */
   function isModuleEnabled(moduleId: string): boolean {
     if (!bridgeStatus.value) return false
+    if (!bridgeStatus.value.methods) return false
 
     const module = BRIDGE_MODULES.find(m => m.id === moduleId)
     if (!module) return false

--- a/src/stores/system.ts
+++ b/src/stores/system.ts
@@ -3,13 +3,27 @@ import { ref, computed } from 'vue'
 import { useAuthStore } from './auth'
 
 /**
- * KanproBridge 外掛狀態
+ * KanproBridge 功能模組狀態（API 回傳格式）
+ */
+export interface BridgeFeature {
+  enabled: boolean
+  methods: Array<{ name: string; description: string }>
+}
+
+/**
+ * KanproBridge 外掛狀態（API 回傳格式）
  */
 export interface KanproBridgeStatus {
   name: string
   version: string
   description?: string
-  methods: string[]
+  features: {
+    jwt_auth: BridgeFeature
+    user_metadata: BridgeFeature
+    user_avatar: BridgeFeature
+    user_password: BridgeFeature
+    user_profile: BridgeFeature
+  }
 }
 
 /**
@@ -19,7 +33,7 @@ export interface BridgeModule {
   id: string
   name: string
   description: string
-  methods: string[]  // 模組需要的 API 方法
+  featureKey: keyof KanproBridgeStatus['features']  // API features 對應的 key
 }
 
 /**
@@ -30,31 +44,31 @@ export const BRIDGE_MODULES: BridgeModule[] = [
     id: 'jwt',
     name: 'JWT 認證',
     description: '登入驗證、Token 管理',
-    methods: ['getJWTToken', 'refreshJWTToken', 'revokeJWTToken']
+    featureKey: 'jwt_auth'
   },
   {
     id: 'avatar',
     name: '使用者頭像',
     description: '頭像上傳與顯示',
-    methods: ['uploadUserAvatar', 'getUserAvatar', 'removeUserAvatar']
+    featureKey: 'user_avatar'
   },
   {
     id: 'metadata',
     name: '使用者元資料',
     description: '偏好設定儲存',
-    methods: ['getUserMetadata', 'getUserMetadataByName', 'saveUserMetadata', 'removeUserMetadata']
+    featureKey: 'user_metadata'
   },
   {
     id: 'password',
     name: '密碼管理',
     description: '密碼變更功能',
-    methods: ['changeUserPassword', 'resetUserPassword']
+    featureKey: 'user_password'
   },
   {
     id: 'profile',
     name: '使用者設定檔',
     description: '個人資料編輯',
-    methods: ['getUserProfile', 'updateUserProfile']
+    featureKey: 'user_profile'
   }
 ]
 
@@ -88,15 +102,14 @@ export const useSystemStore = defineStore('system', () => {
    */
   function isModuleEnabled(moduleId: string): boolean {
     if (!bridgeStatus.value) return false
-    if (!bridgeStatus.value.methods) return false
+    if (!bridgeStatus.value.features) return false
 
     const module = BRIDGE_MODULES.find(m => m.id === moduleId)
     if (!module) return false
 
-    // 檢查模組所需的所有方法是否都存在
-    return module.methods.every(method =>
-      bridgeStatus.value!.methods.includes(method)
-    )
+    // 從 features 中取得對應功能的啟用狀態
+    const feature = bridgeStatus.value.features[module.featureKey]
+    return feature?.enabled ?? false
   }
 
   /**

--- a/src/stores/system.ts
+++ b/src/stores/system.ts
@@ -1,0 +1,236 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useAuthStore } from './auth'
+
+/**
+ * KanproBridge 外掛狀態
+ */
+export interface KanproBridgeStatus {
+  name: string
+  version: string
+  description?: string
+  methods: string[]
+}
+
+/**
+ * KanproBridge 模組定義
+ */
+export interface BridgeModule {
+  id: string
+  name: string
+  description: string
+  methods: string[]  // 模組需要的 API 方法
+}
+
+/**
+ * 預定義的 KanproBridge 模組清單
+ */
+export const BRIDGE_MODULES: BridgeModule[] = [
+  {
+    id: 'jwt',
+    name: 'JWT 認證',
+    description: '登入驗證、Token 管理',
+    methods: ['getJWTToken', 'refreshJWTToken', 'revokeJWTToken']
+  },
+  {
+    id: 'avatar',
+    name: '使用者頭像',
+    description: '頭像上傳與顯示',
+    methods: ['uploadUserAvatar', 'getUserAvatar', 'removeUserAvatar']
+  },
+  {
+    id: 'metadata',
+    name: '使用者元資料',
+    description: '偏好設定儲存',
+    methods: ['getUserMetadata', 'getUserMetadataByName', 'saveUserMetadata', 'removeUserMetadata']
+  },
+  {
+    id: 'password',
+    name: '密碼管理',
+    description: '密碼變更功能',
+    methods: ['changeUserPassword', 'resetUserPassword']
+  },
+  {
+    id: 'profile',
+    name: '使用者設定檔',
+    description: '個人資料編輯',
+    methods: ['getUserProfile', 'updateUserProfile']
+  }
+]
+
+export const useSystemStore = defineStore('system', () => {
+  // === Kanboard 伺服器狀態 ===
+  const kanboardVersion = ref<string | null>(null)
+  const kanboardTimezone = ref<string | null>(null)
+  const apiLatency = ref<number | null>(null)
+  const connectionStatus = ref<'connected' | 'disconnected' | 'checking'>('checking')
+
+  // === KanproBridge 狀態 ===
+  const bridgeStatus = ref<KanproBridgeStatus | null>(null)
+  const bridgeError = ref<string | null>(null)
+
+  // === 載入狀態 ===
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  // === 計算屬性 ===
+
+  /**
+   * 取得 API URL（從 auth store）
+   */
+  const apiUrl = computed(() => {
+    const authStore = useAuthStore()
+    return authStore.apiUrl
+  })
+
+  /**
+   * 檢查模組是否啟用
+   */
+  function isModuleEnabled(moduleId: string): boolean {
+    if (!bridgeStatus.value) return false
+
+    const module = BRIDGE_MODULES.find(m => m.id === moduleId)
+    if (!module) return false
+
+    // 檢查模組所需的所有方法是否都存在
+    return module.methods.every(method =>
+      bridgeStatus.value!.methods.includes(method)
+    )
+  }
+
+  /**
+   * 取得模組狀態列表
+   */
+  const moduleStatuses = computed(() => {
+    return BRIDGE_MODULES.map(module => ({
+      ...module,
+      enabled: isModuleEnabled(module.id)
+    }))
+  })
+
+  // === 方法 ===
+
+  /**
+   * 載入 Kanboard 伺服器資訊
+   */
+  async function fetchKanboardInfo(): Promise<void> {
+    const authStore = useAuthStore()
+
+    connectionStatus.value = 'checking'
+
+    try {
+      const client = authStore.getClient()
+
+      // 測量 API 延遲
+      const startTime = performance.now()
+      const version = await client.call<string>('getVersion')
+      const endTime = performance.now()
+
+      apiLatency.value = Math.round(endTime - startTime)
+      kanboardVersion.value = version
+      connectionStatus.value = 'connected'
+
+      // 取得時區
+      const timezone = await client.call<string>('getTimezone')
+      kanboardTimezone.value = timezone
+    } catch (err) {
+      connectionStatus.value = 'disconnected'
+      error.value = err instanceof Error ? err.message : '無法連線到 Kanboard 伺服器'
+    }
+  }
+
+  /**
+   * 載入 KanproBridge 外掛狀態
+   */
+  async function fetchBridgeStatus(): Promise<void> {
+    const authStore = useAuthStore()
+
+    bridgeError.value = null
+
+    try {
+      const client = authStore.getClient()
+      const status = await client.call<KanproBridgeStatus>('getKanproBridgeStatus')
+      bridgeStatus.value = status
+    } catch (err) {
+      bridgeError.value = err instanceof Error ? err.message : '無法取得 KanproBridge 狀態'
+      bridgeStatus.value = null
+    }
+  }
+
+  /**
+   * 載入所有系統資訊
+   */
+  async function fetchAll(): Promise<void> {
+    isLoading.value = true
+    error.value = null
+
+    try {
+      await Promise.all([
+        fetchKanboardInfo(),
+        fetchBridgeStatus()
+      ])
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /**
+   * 測試 API 連線
+   */
+  async function testConnection(): Promise<{ success: boolean; latency?: number; error?: string }> {
+    const authStore = useAuthStore()
+
+    try {
+      const client = authStore.getClient()
+      const startTime = performance.now()
+      await client.call<string>('getVersion')
+      const endTime = performance.now()
+      const latency = Math.round(endTime - startTime)
+
+      return { success: true, latency }
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : '連線失敗'
+      }
+    }
+  }
+
+  /**
+   * 重置狀態
+   */
+  function $reset(): void {
+    kanboardVersion.value = null
+    kanboardTimezone.value = null
+    apiLatency.value = null
+    connectionStatus.value = 'checking'
+    bridgeStatus.value = null
+    bridgeError.value = null
+    isLoading.value = false
+    error.value = null
+  }
+
+  return {
+    // 狀態
+    kanboardVersion,
+    kanboardTimezone,
+    apiLatency,
+    connectionStatus,
+    bridgeStatus,
+    bridgeError,
+    isLoading,
+    error,
+
+    // 計算屬性
+    apiUrl,
+    moduleStatuses,
+
+    // 方法
+    isModuleEnabled,
+    fetchKanboardInfo,
+    fetchBridgeStatus,
+    fetchAll,
+    testConnection,
+    $reset
+  }
+})

--- a/src/stores/tasks.ts
+++ b/src/stores/tasks.ts
@@ -145,6 +145,29 @@ export const useTasksStore = defineStore('tasks', () => {
     return tasks || []
   }
 
+  /**
+   * 移動任務位置（欄位/泳道/順序）
+   */
+  async function moveTaskPosition(
+    projectId: number,
+    taskId: number,
+    columnId: number,
+    position: number,
+    swimlaneId: number
+  ): Promise<boolean> {
+    const authStore = useAuthStore()
+    const client = authStore.getClient()
+
+    const result = await client.call<boolean>('moveTaskPosition', {
+      project_id: projectId,
+      task_id: taskId,
+      column_id: columnId,
+      position: position,
+      swimlane_id: swimlaneId
+    })
+    return result
+  }
+
   return {
     currentTask,
     allTasks,
@@ -159,6 +182,7 @@ export const useTasksStore = defineStore('tasks', () => {
     clearCurrentTask,
     clearAllTasks,
     searchTasks,
+    moveTaskPosition,
     $reset
   }
 })

--- a/src/stores/toast.ts
+++ b/src/stores/toast.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-export type ToastType = 'success' | 'error' | 'warning' | 'info'
+export type ToastType = 'success' | 'error' | 'warning' | 'info' | 'loading'
 
 export interface Toast {
   id: string
@@ -58,6 +58,11 @@ export const useToastStore = defineStore('toast', () => {
     return add('info', title, message, duration)
   }
 
+  function loading(title: string, message?: string): string {
+    // loading toast 不自動消失（duration = 0）
+    return add('loading', title, message, 0)
+  }
+
   function clear(): void {
     toasts.value = []
   }
@@ -70,6 +75,7 @@ export const useToastStore = defineStore('toast', () => {
     error,
     warning,
     info,
+    loading,
     clear
   }
 })
@@ -84,6 +90,7 @@ export function useToast() {
     error: store.error,
     warning: store.warning,
     info: store.info,
+    loading: store.loading,
     remove: store.remove,
     clear: store.clear
   }

--- a/src/stores/toast.ts
+++ b/src/stores/toast.ts
@@ -42,6 +42,26 @@ export const useToastStore = defineStore('toast', () => {
     }
   }
 
+  /**
+   * 更新現有 toast 的類型和內容（用於 loading -> success/error 轉換）
+   */
+  function update(id: string, type: ToastType, title: string, message?: string, duration = DEFAULT_DURATION): void {
+    const toast = toasts.value.find(t => t.id === id)
+    if (toast) {
+      toast.type = type
+      toast.title = title
+      toast.message = message
+      toast.duration = duration
+
+      // 設定自動移除
+      if (duration > 0) {
+        setTimeout(() => {
+          remove(id)
+        }, duration)
+      }
+    }
+  }
+
   function success(title: string, message?: string, duration = DEFAULT_DURATION): string {
     return add('success', title, message, duration)
   }
@@ -71,6 +91,7 @@ export const useToastStore = defineStore('toast', () => {
     toasts,
     add,
     remove,
+    update,
     success,
     error,
     warning,
@@ -91,6 +112,7 @@ export function useToast() {
     warning: store.warning,
     info: store.info,
     loading: store.loading,
+    update: store.update,
     remove: store.remove,
     clear: store.clear
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -75,28 +75,4 @@
   * {
     @apply transition-colors duration-200;
   }
-
-  /* Custom scrollbar styling */
-  ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-
-  ::-webkit-scrollbar-track {
-    @apply bg-transparent;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    @apply bg-content-tertiary/30 rounded-full;
-  }
-
-  ::-webkit-scrollbar-thumb:hover {
-    @apply bg-content-tertiary/50;
-  }
-
-  /* Firefox scrollbar */
-  * {
-    scrollbar-width: thin;
-    scrollbar-color: var(--color-text-tertiary) transparent;
-  }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -75,4 +75,13 @@
   * {
     @apply transition-colors duration-200;
   }
+
+  /* Hide scrollbar but allow scrolling */
+  .scrollbar-hide {
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;  /* Chrome, Safari, Opera */
+  }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -76,12 +76,29 @@
     @apply transition-colors duration-200;
   }
 
-  /* Hide scrollbar but allow scrolling */
-  .scrollbar-hide {
-    -ms-overflow-style: none;  /* IE and Edge */
-    scrollbar-width: none;  /* Firefox */
+  /* Custom scrollbar - subtle and light */
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
   }
-  .scrollbar-hide::-webkit-scrollbar {
-    display: none;  /* Chrome, Safari, Opera */
+
+  ::-webkit-scrollbar-track {
+    @apply bg-transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    @apply bg-content-tertiary/20 rounded-full;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    @apply bg-content-tertiary/35;
+  }
+
+  /* Firefox */
+  @supports (scrollbar-width: thin) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: rgba(128, 128, 128, 0.2) transparent;
+    }
   }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -75,4 +75,28 @@
   * {
     @apply transition-colors duration-200;
   }
+
+  /* Custom scrollbar styling */
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    @apply bg-transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    @apply bg-content-tertiary/30 rounded-full;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    @apply bg-content-tertiary/50;
+  }
+
+  /* Firefox scrollbar */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-text-tertiary) transparent;
+  }
 }

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -1,0 +1,95 @@
+/**
+ * 任務相關的工具函數
+ */
+
+/**
+ * 檢查任務是否已逾期
+ */
+export function isTaskOverdue(dateDue?: number, isActive?: boolean): boolean {
+  if (!dateDue) return false
+  const overdue = dateDue * 1000 < Date.now()
+  // 如果有提供 isActive 參數，則同時檢查任務是否仍在進行中
+  if (isActive !== undefined) {
+    return overdue && isActive
+  }
+  return overdue
+}
+
+/**
+ * 格式化日期為本地化字串
+ */
+export function formatTaskDate(timestamp?: number): string {
+  if (!timestamp) return '-'
+  return new Date(timestamp * 1000).toLocaleDateString('zh-TW')
+}
+
+/**
+ * 格式化日期為簡短格式（月/日）
+ */
+export function formatShortDate(timestamp?: number): string {
+  if (!timestamp) return ''
+  const date = new Date(timestamp * 1000)
+  return date.toLocaleDateString('zh-TW', {
+    month: 'short',
+    day: 'numeric'
+  })
+}
+
+/**
+ * 任務顏色 ID 對應的圓點 CSS class
+ */
+export const taskColorDotClasses: Record<string, string> = {
+  yellow: 'bg-yellow-500',
+  blue: 'bg-blue-500',
+  green: 'bg-green-500',
+  purple: 'bg-purple-500',
+  red: 'bg-red-500',
+  orange: 'bg-orange-500',
+  grey: 'bg-gray-500',
+  cyan: 'bg-cyan-500',
+  lime: 'bg-lime-500',
+  pink: 'bg-pink-500',
+  teal: 'bg-teal-500',
+  amber: 'bg-amber-500',
+  brown: 'bg-amber-700',
+  deep_orange: 'bg-orange-600',
+  dark_grey: 'bg-gray-600',
+  light_green: 'bg-green-400',
+  white: 'bg-gray-200'
+}
+
+/**
+ * 取得任務顏色圓點的 CSS class
+ */
+export function getTaskColorDotClass(colorId: string): string {
+  return taskColorDotClasses[colorId] || 'bg-yellow-500'
+}
+
+/**
+ * 任務顏色 ID 對應的日曆背景 CSS class
+ */
+export const taskColorBgClasses: Record<string, string> = {
+  yellow: 'bg-yellow-400',
+  blue: 'bg-blue-400',
+  green: 'bg-green-400',
+  purple: 'bg-purple-400',
+  red: 'bg-red-400',
+  orange: 'bg-orange-400',
+  grey: 'bg-gray-400',
+  cyan: 'bg-cyan-400',
+  lime: 'bg-lime-400',
+  pink: 'bg-pink-400',
+  teal: 'bg-teal-400',
+  amber: 'bg-amber-400',
+  brown: 'bg-amber-700',
+  deep_orange: 'bg-orange-600',
+  dark_grey: 'bg-gray-600',
+  white: 'bg-gray-200'
+}
+
+/**
+ * 取得任務顏色背景的 CSS class（用於日曆）
+ */
+export function getTaskColorBgClass(colorId: string): string {
+  return taskColorBgClasses[colorId] || 'bg-gray-400'
+}

--- a/src/views/AdminGroupsView.vue
+++ b/src/views/AdminGroupsView.vue
@@ -192,8 +192,6 @@ const handleRemoveMember = async (userId: number) => {
     <main v-else class="flex-1 p-4 overflow-auto">
       <!-- Toolbar -->
       <div class="card mb-4 p-4 flex items-center gap-4 flex-wrap">
-        <h1 class="text-lg font-semibold text-content whitespace-nowrap">群組管理</h1>
-        <span class="text-content-tertiary">|</span>
         <input
           v-model="filterQuery"
           type="text"

--- a/src/views/AdminGroupsView.vue
+++ b/src/views/AdminGroupsView.vue
@@ -191,17 +191,17 @@ const handleRemoveMember = async (userId: number) => {
     <!-- Content -->
     <main v-else class="flex-1 p-4 overflow-auto">
       <!-- Toolbar -->
-      <div class="card mb-4 p-4 flex items-center gap-4 flex-wrap">
+      <div class="mb-4 flex items-center gap-4 flex-wrap">
+        <span class="text-sm text-content-tertiary whitespace-nowrap">
+          共 {{ filteredGroups.length }} 個群組
+        </span>
+        <div class="flex-1" />
         <input
           v-model="filterQuery"
           type="text"
           placeholder="搜尋群組..."
-          class="input flex-1 min-w-[200px] max-w-md"
+          class="input w-64"
         />
-        <span class="text-sm text-content-tertiary">
-          共 {{ filteredGroups.length }} 個群組
-        </span>
-        <div class="flex-1" />
         <button
           v-if="!isAdding"
           @click="startAdding"

--- a/src/views/AdminGroupsView.vue
+++ b/src/views/AdminGroupsView.vue
@@ -1,0 +1,433 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useGroupsStore } from '@/stores/groups'
+import { useUsersStore } from '@/stores/users'
+import { useToast } from '@/stores/toast'
+import type { Group, User } from '@/types'
+
+const groupsStore = useGroupsStore()
+const usersStore = useUsersStore()
+const toast = useToast()
+
+// Filter state
+const filterQuery = ref('')
+
+// Form state
+const isAdding = ref(false)
+const isSubmitting = ref(false)
+const editingGroupId = ref<number | null>(null)
+
+// New group form
+const newGroupName = ref('')
+const newExternalId = ref('')
+
+// Edit form
+const editName = ref('')
+const editExternalId = ref('')
+
+// Members modal state
+const showMembersModal = ref(false)
+const selectedGroup = ref<Group | null>(null)
+const groupMembers = ref<User[]>([])
+const isLoadingMembers = ref(false)
+const showAddMemberForm = ref(false)
+const selectedUserId = ref<number | null>(null)
+
+// Filtered groups
+const filteredGroups = computed(() => {
+  if (!filterQuery.value.trim()) return groupsStore.groups
+
+  const query = filterQuery.value.toLowerCase()
+  return groupsStore.groups.filter(g =>
+    g.name.toLowerCase().includes(query) ||
+    g.external_id?.toLowerCase().includes(query)
+  )
+})
+
+const availableUsers = computed(() => {
+  const memberIds = new Set(groupMembers.value.map(m => m.id))
+  return usersStore.users.filter(u => !memberIds.has(u.id) && u.is_active)
+})
+
+onMounted(async () => {
+  await Promise.all([
+    groupsStore.fetchAllGroups(),
+    usersStore.fetchAllUsers()
+  ])
+})
+
+const startAdding = () => {
+  isAdding.value = true
+  editingGroupId.value = null
+  newGroupName.value = ''
+  newExternalId.value = ''
+}
+
+const cancelAdding = () => {
+  isAdding.value = false
+}
+
+const handleAddGroup = async () => {
+  if (!newGroupName.value.trim() || isSubmitting.value) return
+
+  isSubmitting.value = true
+
+  try {
+    await groupsStore.createGroup(
+      newGroupName.value.trim(),
+      newExternalId.value.trim() || undefined
+    )
+    await groupsStore.fetchAllGroups()
+    cancelAdding()
+    toast.success('群組新增成功')
+  } catch (err) {
+    toast.error('新增失敗', err instanceof Error ? err.message : '新增群組失敗')
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+const startEditing = (group: Group) => {
+  isAdding.value = false
+  editingGroupId.value = group.id
+  editName.value = group.name
+  editExternalId.value = group.external_id || ''
+}
+
+const cancelEditing = () => {
+  editingGroupId.value = null
+}
+
+const handleSaveGroup = async () => {
+  if (!editingGroupId.value || !editName.value.trim() || isSubmitting.value) return
+
+  isSubmitting.value = true
+
+  try {
+    await groupsStore.updateGroup(
+      editingGroupId.value,
+      editName.value.trim(),
+      editExternalId.value.trim() || undefined
+    )
+    await groupsStore.fetchAllGroups()
+    cancelEditing()
+    toast.success('群組更新成功')
+  } catch (err) {
+    toast.error('更新失敗', err instanceof Error ? err.message : '更新群組失敗')
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+const handleRemoveGroup = async (group: Group) => {
+  if (!confirm(`確定要刪除群組「${group.name}」嗎？此操作無法復原。`)) return
+
+  try {
+    await groupsStore.removeGroup(group.id)
+    await groupsStore.fetchAllGroups()
+    toast.success('群組已刪除')
+  } catch (err) {
+    toast.error('刪除失敗', err instanceof Error ? err.message : '刪除群組失敗')
+  }
+}
+
+const openMembersModal = async (group: Group) => {
+  selectedGroup.value = group
+  showMembersModal.value = true
+  isLoadingMembers.value = true
+  showAddMemberForm.value = false
+  selectedUserId.value = null
+
+  try {
+    groupMembers.value = await groupsStore.getGroupMembers(group.id)
+  } catch (err) {
+    toast.error('載入失敗', err instanceof Error ? err.message : '載入成員失敗')
+  } finally {
+    isLoadingMembers.value = false
+  }
+}
+
+const closeMembersModal = () => {
+  showMembersModal.value = false
+  selectedGroup.value = null
+  groupMembers.value = []
+}
+
+const handleAddMember = async () => {
+  if (!selectedGroup.value || !selectedUserId.value) return
+
+  try {
+    await groupsStore.addGroupMember(selectedGroup.value.id, selectedUserId.value)
+    groupMembers.value = await groupsStore.getGroupMembers(selectedGroup.value.id)
+    showAddMemberForm.value = false
+    selectedUserId.value = null
+    toast.success('成員已加入')
+  } catch (err) {
+    toast.error('加入失敗', err instanceof Error ? err.message : '加入成員失敗')
+  }
+}
+
+const handleRemoveMember = async (userId: number) => {
+  if (!selectedGroup.value) return
+  if (!confirm('確定要移除此成員嗎？')) return
+
+  try {
+    await groupsStore.removeGroupMember(selectedGroup.value.id, userId)
+    groupMembers.value = await groupsStore.getGroupMembers(selectedGroup.value.id)
+    toast.success('成員已移除')
+  } catch (err) {
+    toast.error('移除失敗', err instanceof Error ? err.message : '移除成員失敗')
+  }
+}
+</script>
+
+<template>
+  <div class="h-full flex flex-col bg-surface-secondary">
+    <!-- Loading -->
+    <div v-if="groupsStore.isLoading && groupsStore.groups.length === 0" class="flex-1 flex items-center justify-center">
+      <ph-icon icon="spinner" class="animate-spin h-8 w-8 text-accent" />
+    </div>
+
+    <!-- Content -->
+    <main v-else class="flex-1 p-4 overflow-auto">
+      <!-- Toolbar -->
+      <div class="card mb-4 p-4 flex items-center gap-4 flex-wrap">
+        <h1 class="text-lg font-semibold text-content whitespace-nowrap">群組管理</h1>
+        <span class="text-content-tertiary">|</span>
+        <input
+          v-model="filterQuery"
+          type="text"
+          placeholder="搜尋群組..."
+          class="input flex-1 min-w-[200px] max-w-md"
+        />
+        <span class="text-sm text-content-tertiary">
+          共 {{ filteredGroups.length }} 個群組
+        </span>
+        <div class="flex-1" />
+        <button
+          v-if="!isAdding"
+          @click="startAdding"
+          class="btn-primary"
+        >
+          <ph-icon icon="plus" class="w-4 h-4 mr-1.5" />
+          新增群組
+        </button>
+      </div>
+
+      <!-- Add Group Form -->
+      <div v-if="isAdding" class="card mb-4 p-4">
+        <h2 class="text-base font-semibold text-content mb-4">新增群組</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-content-secondary mb-1">群組名稱 *</label>
+            <input v-model="newGroupName" type="text" class="input" placeholder="輸入群組名稱" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-content-secondary mb-1">外部 ID（選填）</label>
+            <input v-model="newExternalId" type="text" class="input" placeholder="如 LDAP 群組 ID" />
+          </div>
+        </div>
+        <div class="flex gap-2 justify-end mt-4">
+          <button @click="cancelAdding" :disabled="isSubmitting" class="btn-secondary">
+            取消
+          </button>
+          <button
+            @click="handleAddGroup"
+            :disabled="!newGroupName.trim() || isSubmitting"
+            class="btn-primary"
+          >
+            <ph-icon v-if="isSubmitting" icon="spinner" class="w-4 h-4 mr-1.5 animate-spin" />
+            新增
+          </button>
+        </div>
+      </div>
+
+      <!-- Groups Table -->
+      <div class="card overflow-hidden">
+        <table class="table">
+          <thead class="table-header">
+            <tr>
+              <th class="table-header-cell">群組名稱</th>
+              <th class="table-header-cell">外部 ID</th>
+              <th class="table-header-cell w-32 text-right">操作</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-edge">
+            <!-- Edit Row -->
+            <tr v-if="editingGroupId" class="bg-accent/5">
+              <td class="table-cell" colspan="3">
+                <div class="py-2">
+                  <h3 class="text-sm font-medium text-content mb-3">編輯群組</h3>
+                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <label class="block text-sm font-medium text-content-secondary mb-1">群組名稱 *</label>
+                      <input v-model="editName" type="text" class="input" />
+                    </div>
+                    <div>
+                      <label class="block text-sm font-medium text-content-secondary mb-1">外部 ID（選填）</label>
+                      <input v-model="editExternalId" type="text" class="input" />
+                    </div>
+                  </div>
+                  <div class="flex gap-2 justify-end mt-3">
+                    <button @click="cancelEditing" :disabled="isSubmitting" class="btn-secondary btn-sm">
+                      取消
+                    </button>
+                    <button @click="handleSaveGroup" :disabled="!editName.trim() || isSubmitting" class="btn-primary btn-sm">
+                      <ph-icon v-if="isSubmitting" icon="spinner" class="w-4 h-4 mr-1 animate-spin" />
+                      儲存
+                    </button>
+                  </div>
+                </div>
+              </td>
+            </tr>
+
+            <!-- Group Rows -->
+            <tr
+              v-for="group in filteredGroups"
+              :key="group.id"
+              class="table-row"
+            >
+              <td class="table-cell">
+                <div class="flex items-center gap-3">
+                  <div class="w-8 h-8 rounded-full bg-accent/10 flex items-center justify-center">
+                    <ph-icon icon="users-three" class="w-4 h-4 text-accent" />
+                  </div>
+                  <span class="font-medium text-content">{{ group.name }}</span>
+                </div>
+              </td>
+              <td class="table-cell text-content-secondary font-mono text-sm">
+                {{ group.external_id || '-' }}
+              </td>
+              <td class="table-cell text-right">
+                <div class="flex items-center justify-end gap-1">
+                  <button
+                    @click="openMembersModal(group)"
+                    class="p-1.5 text-content-tertiary hover:text-content-secondary hover:bg-surface-hover rounded"
+                    title="管理成員"
+                  >
+                    <ph-icon icon="users" class="w-4 h-4" />
+                  </button>
+                  <button
+                    @click="startEditing(group)"
+                    class="p-1.5 text-content-tertiary hover:text-content-secondary hover:bg-surface-hover rounded"
+                    title="編輯"
+                  >
+                    <ph-icon icon="pencil" class="w-4 h-4" />
+                  </button>
+                  <button
+                    @click="handleRemoveGroup(group)"
+                    class="p-1.5 text-content-tertiary hover:text-error hover:bg-surface-hover rounded"
+                    title="刪除"
+                  >
+                    <ph-icon icon="trash" class="w-4 h-4" />
+                  </button>
+                </div>
+              </td>
+            </tr>
+
+            <!-- Empty State -->
+            <tr v-if="filteredGroups.length === 0">
+              <td colspan="3" class="px-4 py-8 text-center text-content-tertiary">
+                <ph-icon icon="users-three" class="w-12 h-12 mx-auto mb-2 opacity-50" />
+                <p>沒有符合條件的群組</p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </main>
+
+    <!-- Members Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showMembersModal"
+        class="fixed inset-0 z-50 overflow-y-auto"
+      >
+        <div
+          class="fixed inset-0 bg-black/50"
+          @click="closeMembersModal"
+        />
+        <div class="flex min-h-full items-center justify-center p-4">
+          <div class="relative bg-surface rounded-lg shadow-xl w-full max-w-lg">
+            <div class="p-6">
+              <div class="flex items-center justify-between mb-4">
+                <h3 class="text-lg font-semibold text-content">
+                  {{ selectedGroup?.name }} - 成員管理
+                </h3>
+                <button
+                  @click="closeMembersModal"
+                  class="p-1 text-content-tertiary hover:text-content-secondary hover:bg-surface-hover rounded"
+                >
+                  <ph-icon icon="x" class="w-5 h-5" />
+                </button>
+              </div>
+
+              <!-- Loading -->
+              <div v-if="isLoadingMembers" class="text-center py-8">
+                <ph-icon icon="spinner" class="animate-spin h-6 w-6 text-accent mx-auto" />
+              </div>
+
+              <div v-else>
+                <!-- Add member form -->
+                <div v-if="showAddMemberForm" class="mb-4 p-4 bg-surface-secondary rounded-lg">
+                  <label class="block text-sm font-medium text-content-secondary mb-2">選擇使用者</label>
+                  <select v-model="selectedUserId" class="select">
+                    <option :value="null">請選擇</option>
+                    <option v-for="user in availableUsers" :key="user.id" :value="user.id">
+                      {{ user.name || user.username }} (@{{ user.username }})
+                    </option>
+                  </select>
+                  <div class="flex gap-2 justify-end mt-3">
+                    <button @click="showAddMemberForm = false" class="btn-ghost btn-sm">
+                      取消
+                    </button>
+                    <button @click="handleAddMember" :disabled="!selectedUserId" class="btn-primary btn-sm">
+                      加入
+                    </button>
+                  </div>
+                </div>
+
+                <div v-else class="mb-4">
+                  <button @click="showAddMemberForm = true" class="btn-secondary w-full">
+                    <ph-icon icon="plus" class="w-4 h-4 mr-1.5" />
+                    新增成員
+                  </button>
+                </div>
+
+                <!-- Members list -->
+                <div class="space-y-2 max-h-64 overflow-y-auto">
+                  <div
+                    v-for="member in groupMembers"
+                    :key="member.id"
+                    class="flex items-center justify-between p-3 bg-surface-secondary rounded-lg"
+                  >
+                    <div class="flex items-center gap-3">
+                      <div class="avatar-sm">
+                        <span>{{ (member.name || member.username).charAt(0).toUpperCase() }}</span>
+                      </div>
+                      <div>
+                        <p class="font-medium text-content text-sm">{{ member.name || member.username }}</p>
+                        <p class="text-xs text-content-tertiary">@{{ member.username }}</p>
+                      </div>
+                    </div>
+                    <button
+                      @click="handleRemoveMember(member.id)"
+                      class="p-1 text-content-tertiary hover:text-error"
+                      title="移除"
+                    >
+                      <ph-icon icon="x" class="w-4 h-4" />
+                    </button>
+                  </div>
+
+                  <div v-if="groupMembers.length === 0" class="text-center py-4 text-content-tertiary text-sm">
+                    此群組沒有成員
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/src/views/AdminSettingsView.vue
+++ b/src/views/AdminSettingsView.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useSystemStore } from '@/stores/system'
-import { useAuthStore } from '@/stores/auth'
+import { useAppConfig } from '@/composables/useAppConfig'
 import { useToast } from '@/stores/toast'
 
 const systemStore = useSystemStore()
-const authStore = useAuthStore()
+const { configFileApiUrl, getStoredApiUrl } = useAppConfig()
 const toast = useToast()
 
 // Settings Storage Key
 const SETTINGS_KEY = 'kanpro_settings'
 
 // Local settings state
-const autoRefreshInterval = ref(30)
+const boardRefreshInterval = ref(60)
+const notificationCheckInterval = ref(300)
 const enableDesktopNotifications = ref(false)
 
 // Connection test state
@@ -20,13 +21,29 @@ const isTesting = ref(false)
 const testResult = ref<{ success: boolean; latency?: number; error?: string } | null>(null)
 
 // Available refresh intervals
-const refreshIntervalOptions = [
+const boardRefreshOptions = [
   { value: 0, label: '停用' },
-  { value: 15, label: '15 秒' },
   { value: 30, label: '30 秒' },
   { value: 60, label: '1 分鐘' },
+  { value: 120, label: '2 分鐘' },
   { value: 300, label: '5 分鐘' }
 ]
+
+const notificationCheckOptions = [
+  { value: 0, label: '停用' },
+  { value: 60, label: '1 分鐘' },
+  { value: 300, label: '5 分鐘' },
+  { value: 600, label: '10 分鐘' },
+  { value: 1800, label: '30 分鐘' }
+]
+
+// 取得原始配置的 API URL
+function getOriginalApiUrl(): string {
+  const stored = getStoredApiUrl()
+  if (stored) return stored
+  if (configFileApiUrl.value) return configFileApiUrl.value
+  return '-'
+}
 
 // Load settings from localStorage
 function loadSettings(): void {
@@ -34,7 +51,8 @@ function loadSettings(): void {
     const saved = localStorage.getItem(SETTINGS_KEY)
     if (saved) {
       const settings = JSON.parse(saved)
-      autoRefreshInterval.value = settings.autoRefreshInterval ?? 30
+      boardRefreshInterval.value = settings.boardRefreshInterval ?? 60
+      notificationCheckInterval.value = settings.notificationCheckInterval ?? 300
       enableDesktopNotifications.value = settings.enableDesktopNotifications ?? false
     }
   } catch {
@@ -45,11 +63,12 @@ function loadSettings(): void {
 // Save settings to localStorage
 function saveSettings(): void {
   const settings = {
-    autoRefreshInterval: autoRefreshInterval.value,
+    boardRefreshInterval: boardRefreshInterval.value,
+    notificationCheckInterval: notificationCheckInterval.value,
     enableDesktopNotifications: enableDesktopNotifications.value
   }
   localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings))
-  toast.success('設定已儲存', '您的偏好設定已更新')
+  toast.success('設定已儲存')
 }
 
 // Test API connection
@@ -108,140 +127,183 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="h-full overflow-auto bg-surface-secondary">
-    <main class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <!-- Left Column: Connection Settings -->
-        <div class="bg-surface rounded-lg border border-edge p-6">
-          <h2 class="text-lg font-semibold text-content mb-6">連線設定</h2>
+  <div class="h-full flex flex-col bg-surface-secondary">
+    <main class="flex-1 p-4 overflow-auto">
+      <!-- Toolbar -->
+      <div class="card mb-4 p-4">
+        <h1 class="text-lg font-semibold text-content">系統設定</h1>
+      </div>
 
-          <div class="space-y-4">
-            <!-- API URL (read-only) -->
-            <div>
-              <label class="block text-sm font-medium text-content-secondary mb-2">
-                API 位址
-              </label>
-              <div class="flex gap-2">
-                <input
-                  type="text"
-                  :value="authStore.apiUrl"
-                  readonly
-                  class="input flex-1 bg-surface-secondary cursor-not-allowed"
-                  title="API 位址由登入時設定"
-                />
-                <button
-                  @click="testConnection"
-                  :disabled="isTesting"
-                  class="btn-secondary whitespace-nowrap"
-                >
-                  <ph-icon
-                    :icon="isTesting ? 'spinner' : 'plugs-connected'"
-                    :class="['w-4 h-4 mr-2', isTesting && 'animate-spin']"
-                  />
-                  測試連線
-                </button>
-              </div>
-              <p class="mt-1 text-xs text-content-tertiary">
-                API 位址在登入時設定，如需變更請重新登入
-              </p>
-            </div>
-
-            <!-- Connection Test Result -->
-            <div v-if="testResult" class="mt-4">
-              <div
-                :class="[
-                  'p-3 rounded-md',
-                  testResult.success
-                    ? 'bg-success/10 border border-success/20'
-                    : 'bg-error/10 border border-error/20'
-                ]"
-              >
-                <div class="flex items-center gap-2">
-                  <ph-icon
-                    :icon="testResult.success ? 'check-circle' : 'x-circle'"
-                    :class="['w-5 h-5', testResult.success ? 'text-success' : 'text-error']"
-                  />
-                  <span :class="['text-sm font-medium', testResult.success ? 'text-success' : 'text-error']">
-                    {{ testResult.success ? `連線成功 (${testResult.latency}ms)` : '連線失敗' }}
-                  </span>
-                </div>
-                <p v-if="testResult.error" class="mt-1 text-sm text-error">
-                  {{ testResult.error }}
-                </p>
-              </div>
-            </div>
-          </div>
+      <!-- Connection Settings -->
+      <div class="card overflow-hidden mb-4">
+        <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
+          <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
+            連線設定
+          </h2>
         </div>
-
-        <!-- Right Column: Interface Settings -->
-        <div class="bg-surface rounded-lg border border-edge p-6">
-          <h2 class="text-lg font-semibold text-content mb-6">介面設定</h2>
-
-          <div class="space-y-6">
-            <!-- Auto Refresh Interval -->
-            <div>
-              <label class="block text-sm font-medium text-content-secondary mb-2">
-                自動刷新間隔
-              </label>
-              <select
-                v-model="autoRefreshInterval"
-                @change="saveSettings"
-                class="input"
-              >
-                <option
-                  v-for="option in refreshIntervalOptions"
-                  :key="option.value"
-                  :value="option.value"
-                >
-                  {{ option.label }}
-                </option>
-              </select>
-              <p class="mt-1 text-xs text-content-tertiary">
-                設定看板與任務列表的自動刷新頻率
-              </p>
-            </div>
-
-            <!-- Desktop Notifications -->
-            <div class="flex items-center justify-between">
-              <div>
-                <label class="block text-sm font-medium text-content">
-                  啟用桌面通知
-                </label>
-                <p class="text-xs text-content-tertiary">
-                  接收任務更新與提醒的桌面推播
-                </p>
-              </div>
+        <div class="p-4 space-y-4">
+          <!-- API URL -->
+          <div>
+            <label class="block text-sm font-medium text-content-secondary mb-2">
+              API 位址
+            </label>
+            <div class="flex gap-2">
+              <input
+                type="text"
+                :value="getOriginalApiUrl()"
+                readonly
+                class="input flex-1 bg-surface-secondary cursor-not-allowed font-mono text-sm"
+                title="API 位址由登入時設定"
+              />
               <button
-                @click="enableDesktopNotifications = !enableDesktopNotifications; handleNotificationToggle()"
-                :class="[
-                  'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                  enableDesktopNotifications ? 'bg-accent' : 'bg-surface-tertiary'
-                ]"
-                role="switch"
-                :aria-checked="enableDesktopNotifications"
+                @click="testConnection"
+                :disabled="isTesting"
+                class="btn-secondary whitespace-nowrap"
               >
-                <span
-                  :class="[
-                    'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
-                    enableDesktopNotifications ? 'translate-x-6' : 'translate-x-1'
-                  ]"
+                <ph-icon
+                  :icon="isTesting ? 'spinner' : 'plugs-connected'"
+                  :class="['w-4 h-4 mr-1.5', isTesting && 'animate-spin']"
                 />
+                測試連線
               </button>
+            </div>
+            <p class="mt-1.5 text-xs text-content-tertiary">
+              API 位址在登入時設定，如需變更請重新登入
+            </p>
+          </div>
+
+          <!-- Connection Test Result -->
+          <div v-if="testResult">
+            <div
+              :class="[
+                'p-3 rounded-md flex items-center gap-2',
+                testResult.success
+                  ? 'bg-success/10 border border-success/20'
+                  : 'bg-error/10 border border-error/20'
+              ]"
+            >
+              <ph-icon
+                :icon="testResult.success ? 'check-circle' : 'x-circle'"
+                :class="['w-5 h-5', testResult.success ? 'text-success' : 'text-error']"
+              />
+              <span :class="['text-sm font-medium', testResult.success ? 'text-success' : 'text-error']">
+                {{ testResult.success ? `連線成功 (${testResult.latency}ms)` : '連線失敗' }}
+              </span>
+              <span v-if="testResult.error" class="text-sm text-error ml-2">
+                {{ testResult.error }}
+              </span>
             </div>
           </div>
         </div>
       </div>
 
-      <!-- Kanboard Settings Placeholder -->
-      <div class="mt-6 bg-surface rounded-lg border border-dashed border-edge p-6">
-        <div class="flex items-start gap-3">
-          <ph-icon icon="gear" class="w-5 h-5 text-content-tertiary flex-shrink-0 mt-0.5" />
-          <div>
-            <h3 class="text-sm font-medium text-content-tertiary">Kanboard 設定</h3>
-            <p class="text-sm text-content-tertiary mt-1">
-              暫時保留。此區域將顯示可透過 KanproBridge 讀取/修改的伺服器設定。
-            </p>
+      <!-- Auto Refresh Settings -->
+      <div class="card overflow-hidden mb-4">
+        <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
+          <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
+            自動更新
+          </h2>
+        </div>
+        <table class="table">
+          <tbody class="divide-y divide-edge">
+            <tr class="table-row">
+              <td class="table-cell">
+                <div>
+                  <p class="font-medium text-content">看板與任務列表</p>
+                  <p class="text-xs text-content-tertiary mt-0.5">
+                    自動刷新看板和任務列表的資料
+                  </p>
+                </div>
+              </td>
+              <td class="table-cell w-48">
+                <select
+                  v-model="boardRefreshInterval"
+                  @change="saveSettings"
+                  class="select"
+                >
+                  <option
+                    v-for="option in boardRefreshOptions"
+                    :key="option.value"
+                    :value="option.value"
+                  >
+                    {{ option.label }}
+                  </option>
+                </select>
+              </td>
+            </tr>
+            <tr class="table-row">
+              <td class="table-cell">
+                <div>
+                  <p class="font-medium text-content">系統通知檢查</p>
+                  <p class="text-xs text-content-tertiary mt-0.5">
+                    檢查新通知的頻率（任務指派、評論、到期提醒等）
+                  </p>
+                </div>
+              </td>
+              <td class="table-cell w-48">
+                <select
+                  v-model="notificationCheckInterval"
+                  @change="saveSettings"
+                  class="select"
+                >
+                  <option
+                    v-for="option in notificationCheckOptions"
+                    :key="option.value"
+                    :value="option.value"
+                  >
+                    {{ option.label }}
+                  </option>
+                </select>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="px-4 py-3 bg-surface-secondary border-t border-edge">
+          <p class="text-xs text-content-tertiary">
+            <ph-icon icon="info" class="w-3.5 h-3.5 inline mr-1" />
+            自動更新僅在頁面可見時運作，切換到其他分頁時會暫停以節省資源
+          </p>
+        </div>
+      </div>
+
+      <!-- Desktop Notifications -->
+      <div class="card overflow-hidden">
+        <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
+          <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
+            桌面通知
+          </h2>
+        </div>
+        <div class="p-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="font-medium text-content">啟用桌面通知</p>
+              <p class="text-xs text-content-tertiary mt-0.5">
+                接收任務指派、評論、到期提醒的桌面推播
+              </p>
+            </div>
+            <button
+              @click="enableDesktopNotifications = !enableDesktopNotifications; handleNotificationToggle()"
+              :class="[
+                'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+                enableDesktopNotifications ? 'bg-accent' : 'bg-surface-tertiary'
+              ]"
+              role="switch"
+              :aria-checked="enableDesktopNotifications"
+            >
+              <span
+                :class="[
+                  'inline-block h-4 w-4 transform rounded-full bg-white transition-transform shadow-sm',
+                  enableDesktopNotifications ? 'translate-x-6' : 'translate-x-1'
+                ]"
+              />
+            </button>
           </div>
+        </div>
+        <div class="px-4 py-3 bg-surface-secondary border-t border-edge">
+          <p class="text-xs text-content-tertiary">
+            <ph-icon icon="info" class="w-3.5 h-3.5 inline mr-1" />
+            桌面通知需要瀏覽器權限，首次啟用時會要求授權
+          </p>
         </div>
       </div>
     </main>

--- a/src/views/AdminSettingsView.vue
+++ b/src/views/AdminSettingsView.vue
@@ -31,10 +31,12 @@ const boardRefreshOptions = [
 
 const notificationCheckOptions = [
   { value: 0, label: '停用' },
+  { value: 5, label: '5 秒' },
+  { value: 10, label: '10 秒' },
+  { value: 30, label: '30 秒' },
   { value: 60, label: '1 分鐘' },
   { value: 300, label: '5 分鐘' },
-  { value: 600, label: '10 分鐘' },
-  { value: 1800, label: '30 分鐘' }
+  { value: 600, label: '10 分鐘' }
 ]
 
 // 取得原始配置的 API URL
@@ -297,10 +299,14 @@ onMounted(() => {
             </tr>
           </tbody>
         </table>
-        <div class="px-4 py-3 bg-surface-secondary border-t border-edge">
+        <div class="px-4 py-3 bg-surface-secondary border-t border-edge space-y-1">
           <p class="text-xs text-content-tertiary">
             <ph-icon icon="info" class="w-3.5 h-3.5 inline mr-1" />
-            自動更新僅在頁面可見時運作，切換到其他分頁時會暫停以節省資源
+            看板更新僅在頁面可見時運作，切換分頁時會暫停以節省資源
+          </p>
+          <p class="text-xs text-content-tertiary">
+            <ph-icon icon="bell" class="w-3.5 h-3.5 inline mr-1" />
+            通知檢查即使在背景分頁也會持續運作，確保桌面通知正常發送
           </p>
         </div>
       </div>

--- a/src/views/AdminSettingsView.vue
+++ b/src/views/AdminSettingsView.vue
@@ -129,76 +129,115 @@ onMounted(() => {
 <template>
   <div class="h-full flex flex-col bg-surface-secondary">
     <main class="flex-1 p-4 overflow-auto">
-      <!-- Toolbar -->
-      <div class="card mb-4 p-4">
-        <h1 class="text-lg font-semibold text-content">系統設定</h1>
-      </div>
+      <!-- Two Column Layout -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <!-- Left Column: Connection Settings -->
+        <div class="card overflow-hidden">
+          <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
+            <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
+              連線設定
+            </h2>
+          </div>
+          <div class="p-4 space-y-4">
+            <!-- API URL -->
+            <div>
+              <label class="block text-sm font-medium text-content-secondary mb-2">
+                API 位址
+              </label>
+              <div class="flex gap-2">
+                <input
+                  type="text"
+                  :value="getOriginalApiUrl()"
+                  readonly
+                  class="input flex-1 bg-surface-secondary cursor-not-allowed font-mono text-sm"
+                  title="API 位址由登入時設定"
+                />
+                <button
+                  @click="testConnection"
+                  :disabled="isTesting"
+                  class="btn-secondary whitespace-nowrap"
+                >
+                  <ph-icon
+                    :icon="isTesting ? 'spinner' : 'plugs-connected'"
+                    :class="['w-4 h-4 mr-1.5', isTesting && 'animate-spin']"
+                  />
+                  測試
+                </button>
+              </div>
+              <p class="mt-1.5 text-xs text-content-tertiary">
+                API 位址在登入時設定，如需變更請重新登入
+              </p>
+            </div>
 
-      <!-- Connection Settings -->
-      <div class="card overflow-hidden mb-4">
-        <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
-          <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
-            連線設定
-          </h2>
-        </div>
-        <div class="p-4 space-y-4">
-          <!-- API URL -->
-          <div>
-            <label class="block text-sm font-medium text-content-secondary mb-2">
-              API 位址
-            </label>
-            <div class="flex gap-2">
-              <input
-                type="text"
-                :value="getOriginalApiUrl()"
-                readonly
-                class="input flex-1 bg-surface-secondary cursor-not-allowed font-mono text-sm"
-                title="API 位址由登入時設定"
-              />
-              <button
-                @click="testConnection"
-                :disabled="isTesting"
-                class="btn-secondary whitespace-nowrap"
+            <!-- Connection Test Result -->
+            <div v-if="testResult">
+              <div
+                :class="[
+                  'p-3 rounded-md flex items-center gap-2',
+                  testResult.success
+                    ? 'bg-success/10 border border-success/20'
+                    : 'bg-error/10 border border-error/20'
+                ]"
               >
                 <ph-icon
-                  :icon="isTesting ? 'spinner' : 'plugs-connected'"
-                  :class="['w-4 h-4 mr-1.5', isTesting && 'animate-spin']"
+                  :icon="testResult.success ? 'check-circle' : 'x-circle'"
+                  :class="['w-5 h-5', testResult.success ? 'text-success' : 'text-error']"
                 />
-                測試連線
+                <span :class="['text-sm font-medium', testResult.success ? 'text-success' : 'text-error']">
+                  {{ testResult.success ? `連線成功 (${testResult.latency}ms)` : '連線失敗' }}
+                </span>
+                <span v-if="testResult.error" class="text-sm text-error ml-2">
+                  {{ testResult.error }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right Column: Desktop Notifications -->
+        <div class="card overflow-hidden">
+          <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
+            <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
+              桌面通知
+            </h2>
+          </div>
+          <div class="p-4">
+            <div class="flex items-center justify-between">
+              <div>
+                <p class="font-medium text-content">啟用桌面通知</p>
+                <p class="text-xs text-content-tertiary mt-0.5">
+                  接收任務指派、評論、到期提醒的桌面推播
+                </p>
+              </div>
+              <button
+                @click="enableDesktopNotifications = !enableDesktopNotifications; handleNotificationToggle()"
+                :class="[
+                  'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+                  enableDesktopNotifications ? 'bg-accent' : 'bg-surface-tertiary'
+                ]"
+                role="switch"
+                :aria-checked="enableDesktopNotifications"
+              >
+                <span
+                  :class="[
+                    'inline-block h-4 w-4 transform rounded-full bg-white transition-transform shadow-sm',
+                    enableDesktopNotifications ? 'translate-x-6' : 'translate-x-1'
+                  ]"
+                />
               </button>
             </div>
-            <p class="mt-1.5 text-xs text-content-tertiary">
-              API 位址在登入時設定，如需變更請重新登入
-            </p>
           </div>
-
-          <!-- Connection Test Result -->
-          <div v-if="testResult">
-            <div
-              :class="[
-                'p-3 rounded-md flex items-center gap-2',
-                testResult.success
-                  ? 'bg-success/10 border border-success/20'
-                  : 'bg-error/10 border border-error/20'
-              ]"
-            >
-              <ph-icon
-                :icon="testResult.success ? 'check-circle' : 'x-circle'"
-                :class="['w-5 h-5', testResult.success ? 'text-success' : 'text-error']"
-              />
-              <span :class="['text-sm font-medium', testResult.success ? 'text-success' : 'text-error']">
-                {{ testResult.success ? `連線成功 (${testResult.latency}ms)` : '連線失敗' }}
-              </span>
-              <span v-if="testResult.error" class="text-sm text-error ml-2">
-                {{ testResult.error }}
-              </span>
-            </div>
+          <div class="px-4 py-3 bg-surface-secondary border-t border-edge">
+            <p class="text-xs text-content-tertiary">
+              <ph-icon icon="info" class="w-3.5 h-3.5 inline mr-1" />
+              桌面通知需要瀏覽器權限，首次啟用時會要求授權
+            </p>
           </div>
         </div>
       </div>
 
-      <!-- Auto Refresh Settings -->
-      <div class="card overflow-hidden mb-4">
+      <!-- Auto Refresh Settings (Full Width) -->
+      <div class="card overflow-hidden mt-4">
         <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
           <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
             自動更新
@@ -262,47 +301,6 @@ onMounted(() => {
           <p class="text-xs text-content-tertiary">
             <ph-icon icon="info" class="w-3.5 h-3.5 inline mr-1" />
             自動更新僅在頁面可見時運作，切換到其他分頁時會暫停以節省資源
-          </p>
-        </div>
-      </div>
-
-      <!-- Desktop Notifications -->
-      <div class="card overflow-hidden">
-        <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
-          <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
-            桌面通知
-          </h2>
-        </div>
-        <div class="p-4">
-          <div class="flex items-center justify-between">
-            <div>
-              <p class="font-medium text-content">啟用桌面通知</p>
-              <p class="text-xs text-content-tertiary mt-0.5">
-                接收任務指派、評論、到期提醒的桌面推播
-              </p>
-            </div>
-            <button
-              @click="enableDesktopNotifications = !enableDesktopNotifications; handleNotificationToggle()"
-              :class="[
-                'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                enableDesktopNotifications ? 'bg-accent' : 'bg-surface-tertiary'
-              ]"
-              role="switch"
-              :aria-checked="enableDesktopNotifications"
-            >
-              <span
-                :class="[
-                  'inline-block h-4 w-4 transform rounded-full bg-white transition-transform shadow-sm',
-                  enableDesktopNotifications ? 'translate-x-6' : 'translate-x-1'
-                ]"
-              />
-            </button>
-          </div>
-        </div>
-        <div class="px-4 py-3 bg-surface-secondary border-t border-edge">
-          <p class="text-xs text-content-tertiary">
-            <ph-icon icon="info" class="w-3.5 h-3.5 inline mr-1" />
-            桌面通知需要瀏覽器權限，首次啟用時會要求授權
           </p>
         </div>
       </div>

--- a/src/views/AdminSettingsView.vue
+++ b/src/views/AdminSettingsView.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useSystemStore } from '@/stores/system'
+import { useAuthStore } from '@/stores/auth'
+import { useToast } from '@/stores/toast'
+
+const systemStore = useSystemStore()
+const authStore = useAuthStore()
+const toast = useToast()
+
+// Settings Storage Key
+const SETTINGS_KEY = 'kanpro_settings'
+
+// Local settings state
+const autoRefreshInterval = ref(30)
+const enableDesktopNotifications = ref(false)
+
+// Connection test state
+const isTesting = ref(false)
+const testResult = ref<{ success: boolean; latency?: number; error?: string } | null>(null)
+
+// Available refresh intervals
+const refreshIntervalOptions = [
+  { value: 0, label: '停用' },
+  { value: 15, label: '15 秒' },
+  { value: 30, label: '30 秒' },
+  { value: 60, label: '1 分鐘' },
+  { value: 300, label: '5 分鐘' }
+]
+
+// Load settings from localStorage
+function loadSettings(): void {
+  try {
+    const saved = localStorage.getItem(SETTINGS_KEY)
+    if (saved) {
+      const settings = JSON.parse(saved)
+      autoRefreshInterval.value = settings.autoRefreshInterval ?? 30
+      enableDesktopNotifications.value = settings.enableDesktopNotifications ?? false
+    }
+  } catch {
+    // Use defaults
+  }
+}
+
+// Save settings to localStorage
+function saveSettings(): void {
+  const settings = {
+    autoRefreshInterval: autoRefreshInterval.value,
+    enableDesktopNotifications: enableDesktopNotifications.value
+  }
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings))
+  toast.success('設定已儲存', '您的偏好設定已更新')
+}
+
+// Test API connection
+async function testConnection(): Promise<void> {
+  isTesting.value = true
+  testResult.value = null
+
+  const result = await systemStore.testConnection()
+  testResult.value = result
+  isTesting.value = false
+
+  if (result.success) {
+    toast.success('連線成功', `延遲：${result.latency}ms`)
+  } else {
+    toast.error('連線失敗', result.error || '無法連線到伺服器')
+  }
+}
+
+// Request notification permission
+async function requestNotificationPermission(): Promise<void> {
+  if (!('Notification' in window)) {
+    toast.error('不支援', '此瀏覽器不支援桌面通知')
+    enableDesktopNotifications.value = false
+    return
+  }
+
+  if (Notification.permission === 'denied') {
+    toast.error('權限被拒', '請在瀏覽器設定中允許通知')
+    enableDesktopNotifications.value = false
+    return
+  }
+
+  if (Notification.permission === 'default') {
+    const permission = await Notification.requestPermission()
+    if (permission !== 'granted') {
+      enableDesktopNotifications.value = false
+      return
+    }
+  }
+
+  saveSettings()
+}
+
+// Handle notification toggle
+function handleNotificationToggle(): void {
+  if (enableDesktopNotifications.value) {
+    requestNotificationPermission()
+  } else {
+    saveSettings()
+  }
+}
+
+onMounted(() => {
+  loadSettings()
+})
+</script>
+
+<template>
+  <div class="h-full overflow-auto bg-surface-secondary">
+    <main class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <!-- Left Column: Connection Settings -->
+        <div class="bg-surface rounded-lg border border-edge p-6">
+          <h2 class="text-lg font-semibold text-content mb-6">連線設定</h2>
+
+          <div class="space-y-4">
+            <!-- API URL (read-only) -->
+            <div>
+              <label class="block text-sm font-medium text-content-secondary mb-2">
+                API 位址
+              </label>
+              <div class="flex gap-2">
+                <input
+                  type="text"
+                  :value="authStore.apiUrl"
+                  readonly
+                  class="input flex-1 bg-surface-secondary cursor-not-allowed"
+                  title="API 位址由登入時設定"
+                />
+                <button
+                  @click="testConnection"
+                  :disabled="isTesting"
+                  class="btn-secondary whitespace-nowrap"
+                >
+                  <ph-icon
+                    :icon="isTesting ? 'spinner' : 'plugs-connected'"
+                    :class="['w-4 h-4 mr-2', isTesting && 'animate-spin']"
+                  />
+                  測試連線
+                </button>
+              </div>
+              <p class="mt-1 text-xs text-content-tertiary">
+                API 位址在登入時設定，如需變更請重新登入
+              </p>
+            </div>
+
+            <!-- Connection Test Result -->
+            <div v-if="testResult" class="mt-4">
+              <div
+                :class="[
+                  'p-3 rounded-md',
+                  testResult.success
+                    ? 'bg-success/10 border border-success/20'
+                    : 'bg-error/10 border border-error/20'
+                ]"
+              >
+                <div class="flex items-center gap-2">
+                  <ph-icon
+                    :icon="testResult.success ? 'check-circle' : 'x-circle'"
+                    :class="['w-5 h-5', testResult.success ? 'text-success' : 'text-error']"
+                  />
+                  <span :class="['text-sm font-medium', testResult.success ? 'text-success' : 'text-error']">
+                    {{ testResult.success ? `連線成功 (${testResult.latency}ms)` : '連線失敗' }}
+                  </span>
+                </div>
+                <p v-if="testResult.error" class="mt-1 text-sm text-error">
+                  {{ testResult.error }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right Column: Interface Settings -->
+        <div class="bg-surface rounded-lg border border-edge p-6">
+          <h2 class="text-lg font-semibold text-content mb-6">介面設定</h2>
+
+          <div class="space-y-6">
+            <!-- Auto Refresh Interval -->
+            <div>
+              <label class="block text-sm font-medium text-content-secondary mb-2">
+                自動刷新間隔
+              </label>
+              <select
+                v-model="autoRefreshInterval"
+                @change="saveSettings"
+                class="input"
+              >
+                <option
+                  v-for="option in refreshIntervalOptions"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </option>
+              </select>
+              <p class="mt-1 text-xs text-content-tertiary">
+                設定看板與任務列表的自動刷新頻率
+              </p>
+            </div>
+
+            <!-- Desktop Notifications -->
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="block text-sm font-medium text-content">
+                  啟用桌面通知
+                </label>
+                <p class="text-xs text-content-tertiary">
+                  接收任務更新與提醒的桌面推播
+                </p>
+              </div>
+              <button
+                @click="enableDesktopNotifications = !enableDesktopNotifications; handleNotificationToggle()"
+                :class="[
+                  'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+                  enableDesktopNotifications ? 'bg-accent' : 'bg-surface-tertiary'
+                ]"
+                role="switch"
+                :aria-checked="enableDesktopNotifications"
+              >
+                <span
+                  :class="[
+                    'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                    enableDesktopNotifications ? 'translate-x-6' : 'translate-x-1'
+                  ]"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Kanboard Settings Placeholder -->
+      <div class="mt-6 bg-surface rounded-lg border border-dashed border-edge p-6">
+        <div class="flex items-start gap-3">
+          <ph-icon icon="gear" class="w-5 h-5 text-content-tertiary flex-shrink-0 mt-0.5" />
+          <div>
+            <h3 class="text-sm font-medium text-content-tertiary">Kanboard 設定</h3>
+            <p class="text-sm text-content-tertiary mt-1">
+              暫時保留。此區域將顯示可透過 KanproBridge 讀取/修改的伺服器設定。
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>

--- a/src/views/AdminStatusView.vue
+++ b/src/views/AdminStatusView.vue
@@ -1,23 +1,31 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { useSystemStore } from '@/stores/system'
-import { useAuthStore } from '@/stores/auth'
+import { useAppConfig } from '@/composables/useAppConfig'
 
 const systemStore = useSystemStore()
-const authStore = useAuthStore()
+const { configFileApiUrl, getStoredApiUrl } = useAppConfig()
 
 onMounted(async () => {
   await systemStore.fetchAll()
 })
 
-function getConnectionStatusColor(status: string): string {
+// 取得原始配置的 API URL（不是 normalized 的版本）
+function getOriginalApiUrl(): string {
+  const stored = getStoredApiUrl()
+  if (stored) return stored
+  if (configFileApiUrl.value) return configFileApiUrl.value
+  return '-'
+}
+
+function getConnectionStatusBadge(status: string): string {
   switch (status) {
     case 'connected':
-      return 'text-success'
+      return 'badge-success'
     case 'disconnected':
-      return 'text-error'
+      return 'badge-error'
     default:
-      return 'text-content-tertiary'
+      return 'badge-neutral'
   }
 }
 
@@ -28,164 +36,154 @@ function getConnectionStatusText(status: string): string {
     case 'disconnected':
       return '無法連線'
     default:
-      return '檢查中...'
+      return '檢查中'
   }
 }
 </script>
 
 <template>
-  <div class="h-full overflow-auto bg-surface-secondary">
-    <main class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-      <!-- Loading State -->
-      <div v-if="systemStore.isLoading" class="flex items-center justify-center py-12">
-        <ph-icon icon="spinner" class="w-8 h-8 text-accent animate-spin" />
-      </div>
+  <div class="h-full flex flex-col bg-surface-secondary">
+    <!-- Loading -->
+    <div v-if="systemStore.isLoading" class="flex-1 flex items-center justify-center">
+      <ph-icon icon="spinner" class="animate-spin h-8 w-8 text-accent" />
+    </div>
 
-      <!-- Content -->
-      <div v-else class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <!-- Left Column: Kanboard Server -->
-        <div class="bg-surface rounded-lg border border-edge p-6">
-          <h2 class="text-lg font-semibold text-content mb-6">Kanboard 伺服器</h2>
-
-          <div class="space-y-4">
-            <!-- Version -->
-            <div class="flex items-center justify-between py-2 border-b border-edge">
-              <span class="text-sm text-content-tertiary">版本</span>
-              <span class="text-sm font-medium text-content font-mono">
-                {{ systemStore.kanboardVersion || '-' }}
-              </span>
-            </div>
-
-            <!-- Timezone -->
-            <div class="flex items-center justify-between py-2 border-b border-edge">
-              <span class="text-sm text-content-tertiary">時區</span>
-              <span class="text-sm font-medium text-content">
-                {{ systemStore.kanboardTimezone || '-' }}
-              </span>
-            </div>
-
-            <!-- API URL -->
-            <div class="flex items-center justify-between py-2 border-b border-edge">
-              <span class="text-sm text-content-tertiary">API 位址</span>
-              <span class="text-sm text-content truncate max-w-[200px]" :title="authStore.apiUrl">
-                {{ authStore.apiUrl || '-' }}
-              </span>
-            </div>
-
-            <!-- Connection Status -->
-            <div class="flex items-center justify-between py-2">
-              <span class="text-sm text-content-tertiary">連線狀態</span>
-              <span class="flex items-center gap-2">
-                <span
-                  :class="[
-                    'w-2 h-2 rounded-full',
-                    systemStore.connectionStatus === 'connected' ? 'bg-success' :
-                    systemStore.connectionStatus === 'disconnected' ? 'bg-error' : 'bg-content-tertiary'
-                  ]"
-                />
-                <span :class="['text-sm font-medium', getConnectionStatusColor(systemStore.connectionStatus)]">
-                  {{ getConnectionStatusText(systemStore.connectionStatus) }}
-                </span>
-                <span v-if="systemStore.apiLatency !== null" class="text-sm text-content-tertiary">
-                  ({{ systemStore.apiLatency }}ms)
-                </span>
-              </span>
-            </div>
-          </div>
-
-          <!-- Error Message -->
-          <div v-if="systemStore.error" class="mt-4 p-3 bg-error/10 border border-error/20 rounded-md">
-            <p class="text-sm text-error">{{ systemStore.error }}</p>
-          </div>
+    <!-- Content -->
+    <main v-else class="flex-1 p-4 overflow-auto">
+      <!-- Toolbar -->
+      <div class="card mb-4 p-4 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <h1 class="text-lg font-semibold text-content">系統狀態</h1>
+          <span
+            :class="['text-xs', getConnectionStatusBadge(systemStore.connectionStatus)]"
+          >
+            {{ getConnectionStatusText(systemStore.connectionStatus) }}
+            <span v-if="systemStore.apiLatency !== null" class="ml-1">
+              ({{ systemStore.apiLatency }}ms)
+            </span>
+          </span>
         </div>
-
-        <!-- Right Column: KanproBridge Plugin -->
-        <div class="bg-surface rounded-lg border border-edge p-6">
-          <h2 class="text-lg font-semibold text-content mb-6">KanproBridge 外掛</h2>
-
-          <!-- Bridge not available -->
-          <div v-if="systemStore.bridgeError" class="p-4 bg-warning/10 border border-warning/20 rounded-md">
-            <div class="flex items-start gap-3">
-              <ph-icon icon="warning" class="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
-              <div>
-                <p class="text-sm font-medium text-warning">無法取得外掛狀態</p>
-                <p class="text-sm text-content-secondary mt-1">{{ systemStore.bridgeError }}</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Bridge available -->
-          <div v-else-if="systemStore.bridgeStatus" class="space-y-4">
-            <!-- Version -->
-            <div class="flex items-center justify-between py-2 border-b border-edge">
-              <span class="text-sm text-content-tertiary">版本</span>
-              <span class="text-sm font-medium text-content font-mono">
-                {{ systemStore.bridgeStatus.version }}
-              </span>
-            </div>
-
-            <!-- Module Status List -->
-            <div class="pt-2">
-              <h3 class="text-sm font-medium text-content-secondary mb-3">功能模組</h3>
-
-              <div class="space-y-3">
-                <div
-                  v-for="module in systemStore.moduleStatuses"
-                  :key="module.id"
-                  class="flex items-start gap-3"
-                >
-                  <!-- Status Indicator -->
-                  <span
-                    :class="[
-                      'w-2 h-2 rounded-full mt-1.5 flex-shrink-0',
-                      module.enabled ? 'bg-success' : 'bg-content-tertiary/30'
-                    ]"
-                  />
-
-                  <!-- Module Info -->
-                  <div class="flex-1 min-w-0">
-                    <p
-                      :class="[
-                        'text-sm font-medium',
-                        module.enabled ? 'text-content' : 'text-content-tertiary'
-                      ]"
-                    >
-                      {{ module.name }}
-                    </p>
-                    <p
-                      :class="[
-                        'text-xs',
-                        module.enabled ? 'text-content-secondary' : 'text-content-tertiary'
-                      ]"
-                    >
-                      {{ module.description }}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Loading state for bridge -->
-          <div v-else class="flex items-center justify-center py-8">
-            <ph-icon icon="spinner" class="w-6 h-6 text-accent animate-spin" />
-          </div>
-        </div>
-      </div>
-
-      <!-- Refresh Button -->
-      <div class="mt-6 flex justify-end">
         <button
           @click="systemStore.fetchAll"
           :disabled="systemStore.isLoading"
-          class="btn-secondary"
+          class="btn-secondary btn-sm"
         >
           <ph-icon
             icon="arrow-clockwise"
-            :class="['w-4 h-4 mr-2', systemStore.isLoading && 'animate-spin']"
+            :class="['w-4 h-4 mr-1.5', systemStore.isLoading && 'animate-spin']"
           />
           重新整理
         </button>
+      </div>
+
+      <!-- Error Alert -->
+      <div v-if="systemStore.error" class="alert-error mb-4">
+        <div class="flex items-center gap-2">
+          <ph-icon icon="warning" class="w-5 h-5" />
+          <span>{{ systemStore.error }}</span>
+        </div>
+      </div>
+
+      <!-- Kanboard Server Info -->
+      <div class="card overflow-hidden mb-4">
+        <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
+          <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
+            Kanboard 伺服器
+          </h2>
+        </div>
+        <table class="table">
+          <tbody class="divide-y divide-edge">
+            <tr class="table-row">
+              <td class="table-cell text-content-secondary w-48">版本</td>
+              <td class="table-cell font-mono">
+                {{ systemStore.kanboardVersion || '-' }}
+              </td>
+            </tr>
+            <tr class="table-row">
+              <td class="table-cell text-content-secondary">時區</td>
+              <td class="table-cell">
+                {{ systemStore.kanboardTimezone || '-' }}
+              </td>
+            </tr>
+            <tr class="table-row">
+              <td class="table-cell text-content-secondary">API 位址</td>
+              <td class="table-cell font-mono text-sm">
+                {{ getOriginalApiUrl() }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- KanproBridge Plugin -->
+      <div class="card overflow-hidden">
+        <div class="px-4 py-3 bg-surface-secondary border-b border-edge flex items-center justify-between">
+          <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
+            KanproBridge 外掛
+          </h2>
+          <span
+            v-if="systemStore.bridgeStatus"
+            class="badge-success"
+          >
+            v{{ systemStore.bridgeStatus.version }}
+          </span>
+          <span
+            v-else-if="systemStore.bridgeError"
+            class="badge-warning"
+          >
+            未安裝
+          </span>
+        </div>
+
+        <!-- Bridge Error -->
+        <div v-if="systemStore.bridgeError" class="p-4">
+          <div class="alert-warning">
+            <div class="flex items-start gap-3">
+              <ph-icon icon="warning" class="w-5 h-5 flex-shrink-0 mt-0.5" />
+              <div>
+                <p class="font-medium">無法取得外掛狀態</p>
+                <p class="text-sm mt-1 opacity-80">{{ systemStore.bridgeError }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Bridge Modules -->
+        <table v-else-if="systemStore.bridgeStatus" class="table">
+          <thead class="table-header">
+            <tr>
+              <th class="table-header-cell">功能模組</th>
+              <th class="table-header-cell">說明</th>
+              <th class="table-header-cell w-24 text-center">狀態</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-edge">
+            <tr
+              v-for="module in systemStore.moduleStatuses"
+              :key="module.id"
+              class="table-row"
+            >
+              <td class="table-cell font-medium">
+                {{ module.name }}
+              </td>
+              <td class="table-cell text-content-secondary">
+                {{ module.description }}
+              </td>
+              <td class="table-cell text-center">
+                <span
+                  :class="module.enabled ? 'badge-success' : 'badge-neutral'"
+                >
+                  {{ module.enabled ? '啟用' : '停用' }}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <!-- Loading -->
+        <div v-else class="p-8 text-center text-content-tertiary">
+          <ph-icon icon="spinner" class="w-6 h-6 animate-spin mx-auto" />
+        </div>
       </div>
     </main>
   </div>

--- a/src/views/AdminStatusView.vue
+++ b/src/views/AdminStatusView.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useSystemStore } from '@/stores/system'
+import { useAuthStore } from '@/stores/auth'
+
+const systemStore = useSystemStore()
+const authStore = useAuthStore()
+
+onMounted(async () => {
+  await systemStore.fetchAll()
+})
+
+function getConnectionStatusColor(status: string): string {
+  switch (status) {
+    case 'connected':
+      return 'text-success'
+    case 'disconnected':
+      return 'text-error'
+    default:
+      return 'text-content-tertiary'
+  }
+}
+
+function getConnectionStatusText(status: string): string {
+  switch (status) {
+    case 'connected':
+      return '正常'
+    case 'disconnected':
+      return '無法連線'
+    default:
+      return '檢查中...'
+  }
+}
+</script>
+
+<template>
+  <div class="h-full overflow-auto bg-surface-secondary">
+    <main class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <!-- Loading State -->
+      <div v-if="systemStore.isLoading" class="flex items-center justify-center py-12">
+        <ph-icon icon="spinner" class="w-8 h-8 text-accent animate-spin" />
+      </div>
+
+      <!-- Content -->
+      <div v-else class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <!-- Left Column: Kanboard Server -->
+        <div class="bg-surface rounded-lg border border-edge p-6">
+          <h2 class="text-lg font-semibold text-content mb-6">Kanboard 伺服器</h2>
+
+          <div class="space-y-4">
+            <!-- Version -->
+            <div class="flex items-center justify-between py-2 border-b border-edge">
+              <span class="text-sm text-content-tertiary">版本</span>
+              <span class="text-sm font-medium text-content font-mono">
+                {{ systemStore.kanboardVersion || '-' }}
+              </span>
+            </div>
+
+            <!-- Timezone -->
+            <div class="flex items-center justify-between py-2 border-b border-edge">
+              <span class="text-sm text-content-tertiary">時區</span>
+              <span class="text-sm font-medium text-content">
+                {{ systemStore.kanboardTimezone || '-' }}
+              </span>
+            </div>
+
+            <!-- API URL -->
+            <div class="flex items-center justify-between py-2 border-b border-edge">
+              <span class="text-sm text-content-tertiary">API 位址</span>
+              <span class="text-sm text-content truncate max-w-[200px]" :title="authStore.apiUrl">
+                {{ authStore.apiUrl || '-' }}
+              </span>
+            </div>
+
+            <!-- Connection Status -->
+            <div class="flex items-center justify-between py-2">
+              <span class="text-sm text-content-tertiary">連線狀態</span>
+              <span class="flex items-center gap-2">
+                <span
+                  :class="[
+                    'w-2 h-2 rounded-full',
+                    systemStore.connectionStatus === 'connected' ? 'bg-success' :
+                    systemStore.connectionStatus === 'disconnected' ? 'bg-error' : 'bg-content-tertiary'
+                  ]"
+                />
+                <span :class="['text-sm font-medium', getConnectionStatusColor(systemStore.connectionStatus)]">
+                  {{ getConnectionStatusText(systemStore.connectionStatus) }}
+                </span>
+                <span v-if="systemStore.apiLatency !== null" class="text-sm text-content-tertiary">
+                  ({{ systemStore.apiLatency }}ms)
+                </span>
+              </span>
+            </div>
+          </div>
+
+          <!-- Error Message -->
+          <div v-if="systemStore.error" class="mt-4 p-3 bg-error/10 border border-error/20 rounded-md">
+            <p class="text-sm text-error">{{ systemStore.error }}</p>
+          </div>
+        </div>
+
+        <!-- Right Column: KanproBridge Plugin -->
+        <div class="bg-surface rounded-lg border border-edge p-6">
+          <h2 class="text-lg font-semibold text-content mb-6">KanproBridge 外掛</h2>
+
+          <!-- Bridge not available -->
+          <div v-if="systemStore.bridgeError" class="p-4 bg-warning/10 border border-warning/20 rounded-md">
+            <div class="flex items-start gap-3">
+              <ph-icon icon="warning" class="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
+              <div>
+                <p class="text-sm font-medium text-warning">無法取得外掛狀態</p>
+                <p class="text-sm text-content-secondary mt-1">{{ systemStore.bridgeError }}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Bridge available -->
+          <div v-else-if="systemStore.bridgeStatus" class="space-y-4">
+            <!-- Version -->
+            <div class="flex items-center justify-between py-2 border-b border-edge">
+              <span class="text-sm text-content-tertiary">版本</span>
+              <span class="text-sm font-medium text-content font-mono">
+                {{ systemStore.bridgeStatus.version }}
+              </span>
+            </div>
+
+            <!-- Module Status List -->
+            <div class="pt-2">
+              <h3 class="text-sm font-medium text-content-secondary mb-3">功能模組</h3>
+
+              <div class="space-y-3">
+                <div
+                  v-for="module in systemStore.moduleStatuses"
+                  :key="module.id"
+                  class="flex items-start gap-3"
+                >
+                  <!-- Status Indicator -->
+                  <span
+                    :class="[
+                      'w-2 h-2 rounded-full mt-1.5 flex-shrink-0',
+                      module.enabled ? 'bg-success' : 'bg-content-tertiary/30'
+                    ]"
+                  />
+
+                  <!-- Module Info -->
+                  <div class="flex-1 min-w-0">
+                    <p
+                      :class="[
+                        'text-sm font-medium',
+                        module.enabled ? 'text-content' : 'text-content-tertiary'
+                      ]"
+                    >
+                      {{ module.name }}
+                    </p>
+                    <p
+                      :class="[
+                        'text-xs',
+                        module.enabled ? 'text-content-secondary' : 'text-content-tertiary'
+                      ]"
+                    >
+                      {{ module.description }}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Loading state for bridge -->
+          <div v-else class="flex items-center justify-center py-8">
+            <ph-icon icon="spinner" class="w-6 h-6 text-accent animate-spin" />
+          </div>
+        </div>
+      </div>
+
+      <!-- Refresh Button -->
+      <div class="mt-6 flex justify-end">
+        <button
+          @click="systemStore.fetchAll"
+          :disabled="systemStore.isLoading"
+          class="btn-secondary"
+        >
+          <ph-icon
+            icon="arrow-clockwise"
+            :class="['w-4 h-4 mr-2', systemStore.isLoading && 'animate-spin']"
+          />
+          重新整理
+        </button>
+      </div>
+    </main>
+  </div>
+</template>

--- a/src/views/AdminStatusView.vue
+++ b/src/views/AdminStatusView.vue
@@ -50,32 +50,6 @@ function getConnectionStatusText(status: string): string {
 
     <!-- Content -->
     <main v-else class="flex-1 p-4 overflow-auto">
-      <!-- Toolbar -->
-      <div class="card mb-4 p-4 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <h1 class="text-lg font-semibold text-content">系統狀態</h1>
-          <span
-            :class="['text-xs', getConnectionStatusBadge(systemStore.connectionStatus)]"
-          >
-            {{ getConnectionStatusText(systemStore.connectionStatus) }}
-            <span v-if="systemStore.apiLatency !== null" class="ml-1">
-              ({{ systemStore.apiLatency }}ms)
-            </span>
-          </span>
-        </div>
-        <button
-          @click="systemStore.fetchAll"
-          :disabled="systemStore.isLoading"
-          class="btn-secondary btn-sm"
-        >
-          <ph-icon
-            icon="arrow-clockwise"
-            :class="['w-4 h-4 mr-1.5', systemStore.isLoading && 'animate-spin']"
-          />
-          重新整理
-        </button>
-      </div>
-
       <!-- Error Alert -->
       <div v-if="systemStore.error" class="alert-error mb-4">
         <div class="flex items-center gap-2">
@@ -84,105 +58,126 @@ function getConnectionStatusText(status: string): string {
         </div>
       </div>
 
-      <!-- Kanboard Server Info -->
-      <div class="card overflow-hidden mb-4">
-        <div class="px-4 py-3 bg-surface-secondary border-b border-edge">
-          <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
-            Kanboard 伺服器
-          </h2>
+      <!-- Two Column Layout -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <!-- Left Column: Kanboard Server Info -->
+        <div class="card overflow-hidden">
+          <div class="px-4 py-3 bg-surface-secondary border-b border-edge flex items-center justify-between">
+            <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
+              Kanboard 伺服器
+            </h2>
+            <div class="flex items-center gap-2">
+              <span
+                :class="['text-xs', getConnectionStatusBadge(systemStore.connectionStatus)]"
+              >
+                {{ getConnectionStatusText(systemStore.connectionStatus) }}
+                <span v-if="systemStore.apiLatency !== null" class="ml-1">
+                  ({{ systemStore.apiLatency }}ms)
+                </span>
+              </span>
+              <button
+                @click="systemStore.fetchAll"
+                :disabled="systemStore.isLoading"
+                class="p-1 text-content-tertiary hover:text-content-secondary hover:bg-surface-hover rounded"
+                title="重新整理"
+              >
+                <ph-icon
+                  icon="arrow-clockwise"
+                  :class="['w-4 h-4', systemStore.isLoading && 'animate-spin']"
+                />
+              </button>
+            </div>
+          </div>
+          <table class="table">
+            <tbody class="divide-y divide-edge">
+              <tr class="table-row">
+                <td class="table-cell text-content-secondary w-32">版本</td>
+                <td class="table-cell font-mono">
+                  {{ systemStore.kanboardVersion || '-' }}
+                </td>
+              </tr>
+              <tr class="table-row">
+                <td class="table-cell text-content-secondary">時區</td>
+                <td class="table-cell">
+                  {{ systemStore.kanboardTimezone || '-' }}
+                </td>
+              </tr>
+              <tr class="table-row">
+                <td class="table-cell text-content-secondary">API 位址</td>
+                <td class="table-cell font-mono text-sm break-all">
+                  {{ getOriginalApiUrl() }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
-        <table class="table">
-          <tbody class="divide-y divide-edge">
-            <tr class="table-row">
-              <td class="table-cell text-content-secondary w-48">版本</td>
-              <td class="table-cell font-mono">
-                {{ systemStore.kanboardVersion || '-' }}
-              </td>
-            </tr>
-            <tr class="table-row">
-              <td class="table-cell text-content-secondary">時區</td>
-              <td class="table-cell">
-                {{ systemStore.kanboardTimezone || '-' }}
-              </td>
-            </tr>
-            <tr class="table-row">
-              <td class="table-cell text-content-secondary">API 位址</td>
-              <td class="table-cell font-mono text-sm">
-                {{ getOriginalApiUrl() }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
 
-      <!-- KanproBridge Plugin -->
-      <div class="card overflow-hidden">
-        <div class="px-4 py-3 bg-surface-secondary border-b border-edge flex items-center justify-between">
-          <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
-            KanproBridge 外掛
-          </h2>
-          <span
-            v-if="systemStore.bridgeStatus"
-            class="badge-success"
-          >
-            v{{ systemStore.bridgeStatus.version }}
-          </span>
-          <span
-            v-else-if="systemStore.bridgeError"
-            class="badge-warning"
-          >
-            未安裝
-          </span>
-        </div>
+        <!-- Right Column: KanproBridge Plugin -->
+        <div class="card overflow-hidden">
+          <div class="px-4 py-3 bg-surface-secondary border-b border-edge flex items-center justify-between">
+            <h2 class="text-sm font-semibold text-content-secondary uppercase tracking-wide">
+              KanproBridge 外掛
+            </h2>
+            <span
+              v-if="systemStore.bridgeStatus"
+              class="badge-success"
+            >
+              v{{ systemStore.bridgeStatus.version }}
+            </span>
+            <span
+              v-else-if="systemStore.bridgeError"
+              class="badge-warning"
+            >
+              未安裝
+            </span>
+          </div>
 
-        <!-- Bridge Error -->
-        <div v-if="systemStore.bridgeError" class="p-4">
-          <div class="alert-warning">
-            <div class="flex items-start gap-3">
-              <ph-icon icon="warning" class="w-5 h-5 flex-shrink-0 mt-0.5" />
-              <div>
-                <p class="font-medium">無法取得外掛狀態</p>
-                <p class="text-sm mt-1 opacity-80">{{ systemStore.bridgeError }}</p>
+          <!-- Bridge Error -->
+          <div v-if="systemStore.bridgeError" class="p-4">
+            <div class="alert-warning">
+              <div class="flex items-start gap-3">
+                <ph-icon icon="warning" class="w-5 h-5 flex-shrink-0 mt-0.5" />
+                <div>
+                  <p class="font-medium">無法取得外掛狀態</p>
+                  <p class="text-sm mt-1 opacity-80">{{ systemStore.bridgeError }}</p>
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <!-- Bridge Modules -->
-        <table v-else-if="systemStore.bridgeStatus" class="table">
-          <thead class="table-header">
-            <tr>
-              <th class="table-header-cell">功能模組</th>
-              <th class="table-header-cell">說明</th>
-              <th class="table-header-cell w-24 text-center">狀態</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-edge">
-            <tr
-              v-for="module in systemStore.moduleStatuses"
-              :key="module.id"
-              class="table-row"
-            >
-              <td class="table-cell font-medium">
-                {{ module.name }}
-              </td>
-              <td class="table-cell text-content-secondary">
-                {{ module.description }}
-              </td>
-              <td class="table-cell text-center">
-                <span
-                  :class="module.enabled ? 'badge-success' : 'badge-neutral'"
-                >
-                  {{ module.enabled ? '啟用' : '停用' }}
-                </span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+          <!-- Bridge Modules -->
+          <table v-else-if="systemStore.bridgeStatus" class="table">
+            <thead class="table-header">
+              <tr>
+                <th class="table-header-cell">功能模組</th>
+                <th class="table-header-cell w-20 text-center">狀態</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-edge">
+              <tr
+                v-for="module in systemStore.moduleStatuses"
+                :key="module.id"
+                class="table-row"
+              >
+                <td class="table-cell">
+                  <p class="font-medium text-content">{{ module.name }}</p>
+                  <p class="text-xs text-content-tertiary">{{ module.description }}</p>
+                </td>
+                <td class="table-cell text-center">
+                  <span
+                    :class="module.enabled ? 'badge-success' : 'badge-neutral'"
+                  >
+                    {{ module.enabled ? '啟用' : '停用' }}
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
 
-        <!-- Loading -->
-        <div v-else class="p-8 text-center text-content-tertiary">
-          <ph-icon icon="spinner" class="w-6 h-6 animate-spin mx-auto" />
+          <!-- Loading -->
+          <div v-else class="p-8 text-center text-content-tertiary">
+            <ph-icon icon="spinner" class="w-6 h-6 animate-spin mx-auto" />
+          </div>
         </div>
       </div>
     </main>

--- a/src/views/AdminUsersView.vue
+++ b/src/views/AdminUsersView.vue
@@ -1,0 +1,394 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import { useUsersStore } from '@/stores/users'
+import { useToast } from '@/stores/toast'
+import type { User } from '@/types'
+
+const authStore = useAuthStore()
+const usersStore = useUsersStore()
+const toast = useToast()
+
+// Filter state
+const filterQuery = ref('')
+const filterRole = ref<string>('')
+const filterStatus = ref<string>('')
+
+// Form state
+const isAdding = ref(false)
+const isSubmitting = ref(false)
+const editingUserId = ref<number | null>(null)
+
+// New user form
+const newUsername = ref('')
+const newPassword = ref('')
+const newName = ref('')
+const newEmail = ref('')
+const newRole = ref('app-user')
+
+// Edit form
+const editName = ref('')
+const editEmail = ref('')
+const editRole = ref('')
+
+const roles = [
+  { value: 'app-admin', label: '系統管理員' },
+  { value: 'app-manager', label: '專案經理' },
+  { value: 'app-user', label: '一般使用者' }
+]
+
+const getRoleLabel = (role: string) => {
+  return roles.find(r => r.value === role)?.label || role
+}
+
+const getRoleBadgeClass = (role: string) => {
+  switch (role) {
+    case 'app-admin':
+      return 'badge-error'
+    case 'app-manager':
+      return 'badge-info'
+    default:
+      return 'badge-neutral'
+  }
+}
+
+// Filtered users
+const filteredUsers = computed(() => {
+  let users = [...usersStore.users]
+
+  // Filter by query
+  if (filterQuery.value.trim()) {
+    const query = filterQuery.value.toLowerCase()
+    users = users.filter(u =>
+      u.username.toLowerCase().includes(query) ||
+      u.name?.toLowerCase().includes(query) ||
+      u.email?.toLowerCase().includes(query)
+    )
+  }
+
+  // Filter by role
+  if (filterRole.value) {
+    users = users.filter(u => u.role === filterRole.value)
+  }
+
+  // Filter by status
+  if (filterStatus.value) {
+    const isActive = filterStatus.value === 'active'
+    users = users.filter(u => u.is_active === isActive)
+  }
+
+  return users
+})
+
+onMounted(async () => {
+  await usersStore.fetchAllUsers()
+})
+
+const startAdding = () => {
+  isAdding.value = true
+  editingUserId.value = null
+  newUsername.value = ''
+  newPassword.value = ''
+  newName.value = ''
+  newEmail.value = ''
+  newRole.value = 'app-user'
+}
+
+const cancelAdding = () => {
+  isAdding.value = false
+}
+
+const handleAddUser = async () => {
+  if (!newUsername.value.trim() || !newPassword.value || isSubmitting.value) return
+
+  isSubmitting.value = true
+
+  try {
+    await usersStore.createUser({
+      username: newUsername.value.trim(),
+      password: newPassword.value,
+      name: newName.value.trim() || undefined,
+      email: newEmail.value.trim() || undefined,
+      role: newRole.value
+    })
+    await usersStore.fetchAllUsers()
+    cancelAdding()
+    toast.success('使用者新增成功')
+  } catch (err) {
+    toast.error('新增失敗', err instanceof Error ? err.message : '新增使用者失敗')
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+const startEditing = (user: User) => {
+  isAdding.value = false
+  editingUserId.value = user.id
+  editName.value = user.name || ''
+  editEmail.value = user.email || ''
+  editRole.value = user.role
+}
+
+const cancelEditing = () => {
+  editingUserId.value = null
+}
+
+const handleSaveUser = async () => {
+  if (!editingUserId.value || isSubmitting.value) return
+
+  isSubmitting.value = true
+
+  try {
+    await usersStore.updateUser(editingUserId.value, {
+      name: editName.value.trim() || undefined,
+      email: editEmail.value.trim() || undefined,
+      role: editRole.value
+    })
+    await usersStore.fetchAllUsers()
+    cancelEditing()
+    toast.success('使用者更新成功')
+  } catch (err) {
+    toast.error('更新失敗', err instanceof Error ? err.message : '更新使用者失敗')
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+const handleToggleActive = async (user: User) => {
+  try {
+    if (user.is_active) {
+      await usersStore.disableUser(user.id)
+      toast.success('使用者已停用')
+    } else {
+      await usersStore.enableUser(user.id)
+      toast.success('使用者已啟用')
+    }
+    await usersStore.fetchAllUsers()
+  } catch (err) {
+    toast.error('操作失敗', err instanceof Error ? err.message : '切換狀態失敗')
+  }
+}
+
+const handleRemoveUser = async (user: User) => {
+  if (!confirm(`確定要刪除使用者「${user.username}」嗎？此操作無法復原。`)) return
+
+  try {
+    await usersStore.removeUser(user.id)
+    await usersStore.fetchAllUsers()
+    toast.success('使用者已刪除')
+  } catch (err) {
+    toast.error('刪除失敗', err instanceof Error ? err.message : '刪除使用者失敗')
+  }
+}
+</script>
+
+<template>
+  <div class="h-full flex flex-col bg-surface-secondary">
+    <!-- Loading -->
+    <div v-if="usersStore.isLoading && usersStore.users.length === 0" class="flex-1 flex items-center justify-center">
+      <ph-icon icon="spinner" class="animate-spin h-8 w-8 text-accent" />
+    </div>
+
+    <!-- Content -->
+    <main v-else class="flex-1 p-4 overflow-auto">
+      <!-- Toolbar -->
+      <div class="card mb-4 p-4 flex items-center gap-4 flex-wrap">
+        <h1 class="text-lg font-semibold text-content whitespace-nowrap">使用者管理</h1>
+        <span class="text-content-tertiary">|</span>
+        <input
+          v-model="filterQuery"
+          type="text"
+          placeholder="搜尋使用者..."
+          class="input flex-1 min-w-[200px] max-w-md"
+        />
+        <select v-model="filterRole" class="select w-40">
+          <option value="">所有角色</option>
+          <option v-for="role in roles" :key="role.value" :value="role.value">
+            {{ role.label }}
+          </option>
+        </select>
+        <select v-model="filterStatus" class="select w-32">
+          <option value="">所有狀態</option>
+          <option value="active">啟用</option>
+          <option value="inactive">停用</option>
+        </select>
+        <span class="text-sm text-content-tertiary">
+          共 {{ filteredUsers.length }} 位使用者
+        </span>
+        <div class="flex-1" />
+        <button
+          v-if="!isAdding"
+          @click="startAdding"
+          class="btn-primary"
+        >
+          <ph-icon icon="plus" class="w-4 h-4 mr-1.5" />
+          新增使用者
+        </button>
+      </div>
+
+      <!-- Add User Form -->
+      <div v-if="isAdding" class="card mb-4 p-4">
+        <h2 class="text-base font-semibold text-content mb-4">新增使用者</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-content-secondary mb-1">使用者名稱 *</label>
+            <input v-model="newUsername" type="text" class="input" placeholder="輸入使用者名稱" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-content-secondary mb-1">密碼 *</label>
+            <input v-model="newPassword" type="password" class="input" placeholder="輸入密碼" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-content-secondary mb-1">顯示名稱</label>
+            <input v-model="newName" type="text" class="input" placeholder="選填" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-content-secondary mb-1">電子郵件</label>
+            <input v-model="newEmail" type="email" class="input" placeholder="選填" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-content-secondary mb-1">角色</label>
+            <select v-model="newRole" class="select">
+              <option v-for="role in roles" :key="role.value" :value="role.value">
+                {{ role.label }}
+              </option>
+            </select>
+          </div>
+        </div>
+        <div class="flex gap-2 justify-end mt-4">
+          <button @click="cancelAdding" :disabled="isSubmitting" class="btn-secondary">
+            取消
+          </button>
+          <button
+            @click="handleAddUser"
+            :disabled="!newUsername.trim() || !newPassword || isSubmitting"
+            class="btn-primary"
+          >
+            <ph-icon v-if="isSubmitting" icon="spinner" class="w-4 h-4 mr-1.5 animate-spin" />
+            新增
+          </button>
+        </div>
+      </div>
+
+      <!-- Users Table -->
+      <div class="card overflow-hidden">
+        <table class="table">
+          <thead class="table-header">
+            <tr>
+              <th class="table-header-cell">使用者</th>
+              <th class="table-header-cell">電子郵件</th>
+              <th class="table-header-cell">角色</th>
+              <th class="table-header-cell text-center">狀態</th>
+              <th class="table-header-cell w-32 text-right">操作</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-edge">
+            <!-- Edit Row -->
+            <tr v-if="editingUserId" class="bg-accent/5">
+              <td class="table-cell" colspan="5">
+                <div class="py-2">
+                  <h3 class="text-sm font-medium text-content mb-3">編輯使用者</h3>
+                  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div>
+                      <label class="block text-sm font-medium text-content-secondary mb-1">顯示名稱</label>
+                      <input v-model="editName" type="text" class="input" />
+                    </div>
+                    <div>
+                      <label class="block text-sm font-medium text-content-secondary mb-1">電子郵件</label>
+                      <input v-model="editEmail" type="email" class="input" />
+                    </div>
+                    <div>
+                      <label class="block text-sm font-medium text-content-secondary mb-1">角色</label>
+                      <select v-model="editRole" class="select">
+                        <option v-for="role in roles" :key="role.value" :value="role.value">
+                          {{ role.label }}
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                  <div class="flex gap-2 justify-end mt-3">
+                    <button @click="cancelEditing" :disabled="isSubmitting" class="btn-secondary btn-sm">
+                      取消
+                    </button>
+                    <button @click="handleSaveUser" :disabled="isSubmitting" class="btn-primary btn-sm">
+                      <ph-icon v-if="isSubmitting" icon="spinner" class="w-4 h-4 mr-1 animate-spin" />
+                      儲存
+                    </button>
+                  </div>
+                </div>
+              </td>
+            </tr>
+
+            <!-- User Rows -->
+            <tr
+              v-for="user in filteredUsers"
+              :key="user.id"
+              class="table-row"
+              :class="{ 'opacity-50': !user.is_active }"
+            >
+              <td class="table-cell">
+                <div class="flex items-center gap-3">
+                  <div class="avatar-sm">
+                    <span>{{ (user.name || user.username).charAt(0).toUpperCase() }}</span>
+                  </div>
+                  <div>
+                    <p class="font-medium text-content">{{ user.name || user.username }}</p>
+                    <p class="text-xs text-content-tertiary">@{{ user.username }}</p>
+                  </div>
+                </div>
+              </td>
+              <td class="table-cell text-content-secondary">
+                {{ user.email || '-' }}
+              </td>
+              <td class="table-cell">
+                <span :class="getRoleBadgeClass(user.role)">
+                  {{ getRoleLabel(user.role) }}
+                </span>
+              </td>
+              <td class="table-cell text-center">
+                <span :class="user.is_active ? 'badge-success' : 'badge-error'">
+                  {{ user.is_active ? '啟用' : '停用' }}
+                </span>
+              </td>
+              <td class="table-cell text-right">
+                <div class="flex items-center justify-end gap-1">
+                  <button
+                    @click="handleToggleActive(user)"
+                    :disabled="user.id === authStore.user?.id"
+                    class="p-1.5 text-content-tertiary hover:text-content-secondary hover:bg-surface-hover rounded disabled:opacity-30"
+                    :title="user.is_active ? '停用' : '啟用'"
+                  >
+                    <ph-icon :icon="user.is_active ? 'ban' : 'check-circle'" class="w-4 h-4" />
+                  </button>
+                  <button
+                    @click="startEditing(user)"
+                    class="p-1.5 text-content-tertiary hover:text-content-secondary hover:bg-surface-hover rounded"
+                    title="編輯"
+                  >
+                    <ph-icon icon="pencil" class="w-4 h-4" />
+                  </button>
+                  <button
+                    @click="handleRemoveUser(user)"
+                    :disabled="user.id === authStore.user?.id"
+                    class="p-1.5 text-content-tertiary hover:text-error hover:bg-surface-hover rounded disabled:opacity-30"
+                    title="刪除"
+                  >
+                    <ph-icon icon="trash" class="w-4 h-4" />
+                  </button>
+                </div>
+              </td>
+            </tr>
+
+            <!-- Empty State -->
+            <tr v-if="filteredUsers.length === 0">
+              <td colspan="5" class="px-4 py-8 text-center text-content-tertiary">
+                <ph-icon icon="users" class="w-12 h-12 mx-auto mb-2 opacity-50" />
+                <p>沒有符合條件的使用者</p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </main>
+  </div>
+</template>

--- a/src/views/AdminUsersView.vue
+++ b/src/views/AdminUsersView.vue
@@ -192,13 +192,11 @@ const handleRemoveUser = async (user: User) => {
     <!-- Content -->
     <main v-else class="flex-1 p-4 overflow-auto">
       <!-- Toolbar -->
-      <div class="card mb-4 p-4 flex items-center gap-4 flex-wrap">
-        <input
-          v-model="filterQuery"
-          type="text"
-          placeholder="搜尋使用者..."
-          class="input flex-1 min-w-[200px] max-w-md"
-        />
+      <div class="mb-4 flex items-center gap-4 flex-wrap">
+        <span class="text-sm text-content-tertiary whitespace-nowrap">
+          共 {{ filteredUsers.length }} 位使用者
+        </span>
+        <div class="flex-1" />
         <select v-model="filterRole" class="select w-40">
           <option value="">所有角色</option>
           <option v-for="role in roles" :key="role.value" :value="role.value">
@@ -210,10 +208,12 @@ const handleRemoveUser = async (user: User) => {
           <option value="active">啟用</option>
           <option value="inactive">停用</option>
         </select>
-        <span class="text-sm text-content-tertiary">
-          共 {{ filteredUsers.length }} 位使用者
-        </span>
-        <div class="flex-1" />
+        <input
+          v-model="filterQuery"
+          type="text"
+          placeholder="搜尋使用者..."
+          class="input w-64"
+        />
         <button
           v-if="!isAdding"
           @click="startAdding"

--- a/src/views/AdminUsersView.vue
+++ b/src/views/AdminUsersView.vue
@@ -193,8 +193,6 @@ const handleRemoveUser = async (user: User) => {
     <main v-else class="flex-1 p-4 overflow-auto">
       <!-- Toolbar -->
       <div class="card mb-4 p-4 flex items-center gap-4 flex-wrap">
-        <h1 class="text-lg font-semibold text-content whitespace-nowrap">使用者管理</h1>
-        <span class="text-content-tertiary">|</span>
         <input
           v-model="filterQuery"
           type="text"

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -251,7 +251,7 @@ const hasMultipleSwimlanes = computed(() => boardStore.swimlanes.length > 1)
           <!-- Columns (collapsible) -->
           <div
             v-show="!isSwimlaneCollapsed(swimlane.id)"
-            class="flex gap-4 overflow-x-auto pb-2"
+            class="flex gap-4 overflow-x-auto pb-4"
           >
             <div
               v-for="column in swimlane.columns"

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -139,6 +139,9 @@ const handleDragEnd = async (evt: { item: HTMLElement; to: HTMLElement; newIndex
 
   if (!taskId || !columnId || !swimlaneId) return
 
+  // 顯示 loading 通知
+  const loadingId = toast.loading('正在更新...')
+
   try {
     await tasksStore.moveTaskPosition(
       projectId.value,
@@ -147,13 +150,18 @@ const handleDragEnd = async (evt: { item: HTMLElement; to: HTMLElement; newIndex
       position,
       swimlaneId
     )
-    // Refresh board to get updated positions
-    await boardStore.fetchBoard(projectId.value)
+    // 先顯示成功通知，再關閉 loading
+    toast.success('任務已移動')
+    toast.remove(loadingId)
+    // 靜默刷新以同步伺服器狀態（不顯示 loading）
+    await boardStore.fetchBoard(projectId.value, true)
   } catch (error) {
     console.error('Failed to move task:', error)
+    // 先顯示失敗通知，再關閉 loading
     toast.error('移動任務失敗')
-    // Refresh to revert UI state
-    await boardStore.fetchBoard(projectId.value)
+    toast.remove(loadingId)
+    // 靜默刷新以還原 UI 狀態
+    await boardStore.fetchBoard(projectId.value, true)
   }
 }
 

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -150,16 +150,14 @@ const handleDragEnd = async (evt: { item: HTMLElement; to: HTMLElement; newIndex
       position,
       swimlaneId
     )
-    // 先顯示成功通知，再關閉 loading
-    toast.success('任務已移動')
-    toast.remove(loadingId)
+    // 將 loading 替換為成功通知（漸變動畫）
+    toast.update(loadingId, 'success', '任務已移動')
     // 靜默刷新以同步伺服器狀態（不顯示 loading）
     await boardStore.fetchBoard(projectId.value, true)
   } catch (error) {
     console.error('Failed to move task:', error)
-    // 先顯示失敗通知，再關閉 loading
-    toast.error('移動任務失敗')
-    toast.remove(loadingId)
+    // 將 loading 替換為失敗通知（漸變動畫）
+    toast.update(loadingId, 'error', '移動任務失敗')
     // 靜默刷新以還原 UI 狀態
     await boardStore.fetchBoard(projectId.value, true)
   }

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -251,7 +251,7 @@ const hasMultipleSwimlanes = computed(() => boardStore.swimlanes.length > 1)
           <!-- Columns (collapsible) -->
           <div
             v-show="!isSwimlaneCollapsed(swimlane.id)"
-            class="flex gap-4 overflow-x-auto pb-2 scrollbar-hide"
+            class="flex gap-4 overflow-x-auto pb-6"
           >
             <div
               v-for="column in swimlane.columns"

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -3,6 +3,8 @@ import { ref, onMounted, watch, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useBoardStore } from '@/stores/board'
 import { useTasksStore } from '@/stores/tasks'
+import { useToast } from '@/stores/toast'
+import draggable from 'vuedraggable'
 import TaskCard from '@/components/TaskCard.vue'
 import TaskFormModal from '@/components/TaskFormModal.vue'
 import TaskDetailModal from '@/components/TaskDetailModal.vue'
@@ -21,20 +23,29 @@ const route = useRoute()
 const router = useRouter()
 const boardStore = useBoardStore()
 const tasksStore = useTasksStore()
+const toast = useToast()
 
 const projectId = computed(() => Number(route.params.id))
+
+// Collapsed swimlanes state
+const collapsedSwimlanes = ref<Set<number>>(new Set())
 
 // Modal state
 const showTaskModal = ref(false)
 const defaultColumnId = ref<number>(0)
+const defaultSwimlaneId = ref<number>(0)
 const taskModalRef = ref<InstanceType<typeof TaskFormModal> | null>(null)
 
 // Task detail modal state
 const showTaskDetailModal = ref(false)
 const selectedTask = ref<Task | null>(null)
 
+// Drag state
+const isDragging = ref(false)
+
 onMounted(() => {
   boardStore.fetchBoard(projectId.value)
+  loadCollapsedState()
 })
 
 watch(() => route.params.id, (newId) => {
@@ -49,13 +60,15 @@ watch(
   async (taskId) => {
     if (taskId) {
       const id = Number(taskId)
-      // Find task in board columns
-      for (const column of boardStore.columns) {
-        const task = column.tasks.find(t => t.id === id)
-        if (task) {
-          selectedTask.value = task
-          showTaskDetailModal.value = true
-          break
+      // Find task in board swimlanes
+      for (const swimlane of boardStore.swimlanes) {
+        for (const column of swimlane.columns) {
+          const task = column.tasks.find(t => t.id === id)
+          if (task) {
+            selectedTask.value = task
+            showTaskDetailModal.value = true
+            break
+          }
         }
       }
       // Clear query param
@@ -71,7 +84,6 @@ const handleTaskClick = (task: Task) => {
 }
 
 const handleTaskUpdated = async () => {
-  // Refresh board to get updated task data
   await boardStore.fetchBoard(projectId.value)
 }
 
@@ -81,8 +93,9 @@ const handleSearchSelect = (task: Task) => {
   emit('close-search-modal')
 }
 
-const openAddTaskModal = (columnId: number) => {
+const openAddTaskModal = (columnId: number, swimlaneId: number) => {
   defaultColumnId.value = columnId
+  defaultSwimlaneId.value = swimlaneId
   showTaskModal.value = true
 }
 
@@ -98,18 +111,90 @@ const handleCreateTask = async (data: {
       title: data.title,
       description: data.description || undefined,
       color_id: data.color_id,
-      column_id: data.column_id
+      column_id: data.column_id,
+      swimlane_id: defaultSwimlaneId.value || undefined
     })
     showTaskModal.value = false
-    // Refresh board
     await boardStore.fetchBoard(projectId.value)
   } catch (error) {
     console.error('Failed to create task:', error)
-    alert('建立任務失敗')
+    toast.error('建立任務失敗')
   } finally {
     taskModalRef.value?.setSubmitting(false)
   }
 }
+
+// Drag and drop handlers
+const handleDragStart = () => {
+  isDragging.value = true
+}
+
+const handleDragEnd = async (evt: { item: HTMLElement; to: HTMLElement; newIndex: number }) => {
+  isDragging.value = false
+
+  const taskId = Number(evt.item.dataset.taskId)
+  const columnId = Number(evt.to.dataset.columnId)
+  const swimlaneId = Number(evt.to.dataset.swimlaneId)
+  const position = evt.newIndex + 1 // Kanboard uses 1-based position
+
+  if (!taskId || !columnId || !swimlaneId) return
+
+  try {
+    await tasksStore.moveTaskPosition(
+      projectId.value,
+      taskId,
+      columnId,
+      position,
+      swimlaneId
+    )
+    // Refresh board to get updated positions
+    await boardStore.fetchBoard(projectId.value)
+  } catch (error) {
+    console.error('Failed to move task:', error)
+    toast.error('移動任務失敗')
+    // Refresh to revert UI state
+    await boardStore.fetchBoard(projectId.value)
+  }
+}
+
+// Swimlane collapse/expand
+const toggleSwimlane = (swimlaneId: number) => {
+  if (collapsedSwimlanes.value.has(swimlaneId)) {
+    collapsedSwimlanes.value.delete(swimlaneId)
+  } else {
+    collapsedSwimlanes.value.add(swimlaneId)
+  }
+  saveCollapsedState()
+}
+
+const isSwimlaneCollapsed = (swimlaneId: number) => {
+  return collapsedSwimlanes.value.has(swimlaneId)
+}
+
+const getSwimlaneTaskCount = (swimlane: typeof boardStore.swimlanes[0]) => {
+  return swimlane.columns.reduce((sum, col) => sum + col.tasks.length, 0)
+}
+
+// Persist collapsed state
+const loadCollapsedState = () => {
+  const saved = localStorage.getItem(`kanpro_collapsed_swimlanes_${projectId.value}`)
+  if (saved) {
+    try {
+      const ids = JSON.parse(saved) as number[]
+      collapsedSwimlanes.value = new Set(ids)
+    } catch {
+      // ignore
+    }
+  }
+}
+
+const saveCollapsedState = () => {
+  const ids = Array.from(collapsedSwimlanes.value)
+  localStorage.setItem(`kanpro_collapsed_swimlanes_${projectId.value}`, JSON.stringify(ids))
+}
+
+// Check if project has multiple swimlanes
+const hasMultipleSwimlanes = computed(() => boardStore.swimlanes.length > 1)
 </script>
 
 <template>
@@ -133,46 +218,94 @@ const handleCreateTask = async (data: {
     </div>
 
     <!-- Board -->
-    <main v-else class="flex-1 overflow-x-auto p-4">
-      <div class="flex gap-4 h-full min-w-max">
-        <!-- Columns -->
+    <main v-else class="flex-1 overflow-auto p-4">
+      <!-- Swimlanes -->
+      <div class="space-y-4">
         <div
-          v-for="column in boardStore.columns"
-          :key="column.id"
-          class="w-72 flex-shrink-0 bg-surface-tertiary rounded-lg flex flex-col max-h-full"
+          v-for="swimlane in boardStore.swimlanes"
+          :key="swimlane.id"
+          class="swimlane"
         >
-          <!-- Column Header -->
-          <div class="p-3 flex items-center justify-between">
-            <div class="flex items-center gap-2">
-              <h3 class="font-semibold text-content-secondary">{{ column.title }}</h3>
-              <span class="text-xs text-content-tertiary bg-surface-active px-1.5 py-0.5 rounded">
-                {{ column.nb_tasks }}
-              </span>
-            </div>
-            <button
-              @click="openAddTaskModal(column.id)"
-              class="text-content-tertiary hover:text-content-secondary"
-              title="新增任務"
-            >
-              <ph-icon icon="plus" class="w-5 h-5" />
-            </button>
+          <!-- Swimlane Header (only show if multiple swimlanes) -->
+          <div
+            v-if="hasMultipleSwimlanes"
+            @click="toggleSwimlane(swimlane.id)"
+            class="flex items-center gap-2 px-2 py-2 mb-2 cursor-pointer hover:bg-surface-hover rounded-lg transition-colors"
+          >
+            <ph-icon
+              :icon="isSwimlaneCollapsed(swimlane.id) ? 'chevron-right' : 'chevron-down'"
+              class="w-4 h-4 text-content-tertiary"
+            />
+            <span class="font-semibold text-content-secondary">{{ swimlane.name }}</span>
+            <span class="text-xs text-content-tertiary bg-surface-active px-1.5 py-0.5 rounded">
+              {{ getSwimlaneTaskCount(swimlane) }}
+            </span>
           </div>
 
-          <!-- Tasks -->
-          <div class="flex-1 overflow-y-auto p-2 space-y-2">
-            <TaskCard
-              v-for="task in column.tasks"
-              :key="task.id"
-              :task="task"
-              @click="handleTaskClick"
-            />
-
-            <!-- Empty state -->
+          <!-- Columns (collapsible) -->
+          <div
+            v-show="!isSwimlaneCollapsed(swimlane.id)"
+            class="flex gap-4 overflow-x-auto pb-2"
+          >
             <div
-              v-if="column.tasks.length === 0"
-              class="text-center py-8 text-content-tertiary text-sm"
+              v-for="column in swimlane.columns"
+              :key="column.id"
+              class="w-72 flex-shrink-0 bg-surface-tertiary rounded-lg flex flex-col max-h-[calc(100vh-200px)]"
             >
-              無任務
+              <!-- Column Header -->
+              <div class="p-3 flex items-center justify-between border-b border-edge/50">
+                <div class="flex items-center gap-2">
+                  <h3 class="font-semibold text-content-secondary">{{ column.title }}</h3>
+                  <span class="text-xs text-content-tertiary bg-surface-active px-1.5 py-0.5 rounded">
+                    {{ column.tasks.length }}
+                  </span>
+                  <span
+                    v-if="column.task_limit > 0 && column.tasks.length >= column.task_limit"
+                    class="text-xs text-error font-medium"
+                    title="已達 WIP 限制"
+                  >
+                    WIP
+                  </span>
+                </div>
+                <button
+                  @click.stop="openAddTaskModal(column.id, swimlane.id)"
+                  class="text-content-tertiary hover:text-content-secondary"
+                  title="新增任務"
+                >
+                  <ph-icon icon="plus" class="w-5 h-5" />
+                </button>
+              </div>
+
+              <!-- Tasks (draggable) -->
+              <draggable
+                :list="column.tasks"
+                :group="{ name: 'tasks', pull: true, put: true }"
+                item-key="id"
+                class="flex-1 overflow-y-auto p-2 space-y-2 min-h-[60px]"
+                :data-column-id="column.id"
+                :data-swimlane-id="swimlane.id"
+                ghost-class="opacity-50"
+                drag-class="shadow-lg"
+                @start="handleDragStart"
+                @end="handleDragEnd"
+              >
+                <template #item="{ element: task }">
+                  <div :data-task-id="task.id">
+                    <TaskCard
+                      :task="task"
+                      @click="handleTaskClick"
+                    />
+                  </div>
+                </template>
+              </draggable>
+
+              <!-- Empty state -->
+              <div
+                v-if="column.tasks.length === 0"
+                class="text-center py-8 text-content-tertiary text-sm"
+              >
+                無任務
+              </div>
             </div>
           </div>
         </div>

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -134,12 +134,7 @@ const handleCreateTask = async (data: {
 
     <!-- Board -->
     <main v-else class="flex-1 overflow-x-auto p-4">
-      <!-- Project Name -->
-      <div class="mb-3 flex items-center gap-2">
-        <h1 class="text-lg font-semibold text-content">{{ boardStore.project?.name || '看板' }}</h1>
-        <span class="text-sm text-content-tertiary">· {{ boardStore.columns.length }} 欄位</span>
-      </div>
-      <div class="flex gap-4 h-[calc(100%-2rem)] min-w-max">
+      <div class="flex gap-4 h-full min-w-max">
         <!-- Columns -->
         <div
           v-for="column in boardStore.columns"

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -251,7 +251,7 @@ const hasMultipleSwimlanes = computed(() => boardStore.swimlanes.length > 1)
           <!-- Columns (collapsible) -->
           <div
             v-show="!isSwimlaneCollapsed(swimlane.id)"
-            class="flex gap-4 overflow-x-auto pb-4"
+            class="flex gap-4 overflow-x-auto pb-2 scrollbar-hide"
           >
             <div
               v-for="column in swimlane.columns"

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useTasksStore } from '@/stores/tasks'
 import { useBoardStore } from '@/stores/board'
+import { getTaskColorBgClass } from '@/utils/task'
 import TaskDetailModal from '@/components/TaskDetailModal.vue'
 import SearchModal from '@/components/SearchModal.vue'
 import type { Task } from '@/types'
@@ -124,28 +125,6 @@ const goToToday = () => {
   currentDate.value = new Date()
 }
 
-// Task color mapping
-const getTaskColor = (colorId: string): string => {
-  const colorMap: Record<string, string> = {
-    yellow: 'bg-yellow-400',
-    blue: 'bg-blue-400',
-    green: 'bg-green-400',
-    purple: 'bg-purple-400',
-    red: 'bg-red-400',
-    orange: 'bg-orange-400',
-    grey: 'bg-gray-400',
-    cyan: 'bg-cyan-400',
-    lime: 'bg-lime-400',
-    pink: 'bg-pink-400',
-    teal: 'bg-teal-400',
-    amber: 'bg-amber-400',
-    brown: 'bg-amber-700',
-    deep_orange: 'bg-orange-600',
-    dark_grey: 'bg-gray-600',
-    white: 'bg-gray-200'
-  }
-  return colorMap[colorId] || 'bg-gray-400'
-}
 
 // Open task modal
 const openTaskModal = (task: Task) => {
@@ -264,7 +243,7 @@ watch(projectId, () => {
                 @click="openTaskModal(task)"
                 :class="[
                   'calendar-task text-xs px-1 py-0.5 rounded truncate cursor-pointer hover:opacity-80',
-                  getTaskColor(task.color_id),
+                  getTaskColorBgClass(task.color_id),
                   task.color_id === 'white' ? 'text-content-secondary' : 'text-white'
                 ]"
                 :title="task.title"

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -191,8 +191,6 @@ watch(projectId, () => {
     >
       <!-- Month/Year Navigation -->
       <div class="flex items-center gap-4">
-        <h1 class="text-lg font-semibold text-content">日曆</h1>
-        <span class="text-content-tertiary">|</span>
         <button
           data-testid="today-btn"
           @click="goToToday"

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -189,9 +189,9 @@ watch(projectId, () => {
       data-testid="calendar-header"
       class="px-6 py-4 flex items-center justify-between bg-surface border-b border-edge"
     >
-      <!-- Project Name & Month/Year Navigation -->
+      <!-- Month/Year Navigation -->
       <div class="flex items-center gap-4">
-        <h1 class="text-lg font-semibold text-content">{{ boardStore.project?.name || '日曆' }}</h1>
+        <h1 class="text-lg font-semibold text-content">日曆</h1>
         <span class="text-content-tertiary">|</span>
         <button
           data-testid="today-btn"

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -184,15 +184,11 @@ const handleSearchSelect = (task: Task) => {
     <!-- Content -->
     <main v-else class="flex-1 p-4 overflow-auto">
       <!-- Toolbar -->
-      <div class="card mb-4 p-4 flex items-center gap-4">
-        <h1 class="text-lg font-semibold text-content whitespace-nowrap">任務清單</h1>
-        <span class="text-content-tertiary">|</span>
-        <input
-          v-model="filterQuery"
-          type="text"
-          :placeholder="`搜尋任務...`"
-          class="input flex-1 max-w-md"
-        />
+      <div class="mb-4 flex items-center gap-4">
+        <span class="text-sm text-content-tertiary whitespace-nowrap">
+          共 {{ filteredTasks.length }} 個任務
+        </span>
+        <div class="flex-1" />
         <label class="flex items-center gap-2 text-sm text-content-secondary">
           <input
             v-model="showClosedTasks"
@@ -201,9 +197,12 @@ const handleSearchSelect = (task: Task) => {
           />
           顯示已關閉任務
         </label>
-        <span class="text-sm text-content-tertiary">
-          共 {{ filteredTasks.length }} 個任務
-        </span>
+        <input
+          v-model="filterQuery"
+          type="text"
+          :placeholder="`搜尋任務...`"
+          class="input w-64"
+        />
       </div>
 
       <!-- Table -->

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -185,7 +185,7 @@ const handleSearchSelect = (task: Task) => {
     <main v-else class="flex-1 p-4 overflow-auto">
       <!-- Toolbar -->
       <div class="card mb-4 p-4 flex items-center gap-4">
-        <h1 class="text-lg font-semibold text-content whitespace-nowrap">{{ boardStore.project?.name || '任務列表' }}</h1>
+        <h1 class="text-lg font-semibold text-content whitespace-nowrap">任務清單</h1>
         <span class="text-content-tertiary">|</span>
         <input
           v-model="filterQuery"

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useBoardStore } from '@/stores/board'
 import { useTasksStore } from '@/stores/tasks'
+import { isTaskOverdue, formatTaskDate, getTaskColorDotClass } from '@/utils/task'
 import TaskDetailModal from '@/components/TaskDetailModal.vue'
 import SearchModal from '@/components/SearchModal.vue'
 import type { Task } from '@/types'
@@ -34,31 +35,6 @@ const showClosedTasks = ref(false)
 // Task detail modal
 const showTaskDetailModal = ref(false)
 const selectedTask = ref<Task | null>(null)
-
-const colorClasses: Record<string, string> = {
-  yellow: 'bg-yellow-500',
-  blue: 'bg-blue-500',
-  green: 'bg-green-500',
-  purple: 'bg-purple-500',
-  red: 'bg-red-500',
-  orange: 'bg-orange-500',
-  grey: 'bg-gray-500',
-  cyan: 'bg-cyan-500'
-}
-
-const getColorClass = (colorId: string) => {
-  return colorClasses[colorId] || 'bg-yellow-500'
-}
-
-const formatDate = (timestamp?: number) => {
-  if (!timestamp) return '-'
-  return new Date(timestamp * 1000).toLocaleDateString('zh-TW')
-}
-
-const isOverdue = (task: Task) => {
-  if (!task.date_due) return false
-  return task.date_due * 1000 < Date.now() && task.is_active
-}
 
 const getColumnName = (columnId: number) => {
   const column = boardStore.columns.find(c => c.id === columnId)
@@ -263,7 +239,7 @@ const handleSearchSelect = (task: Task) => {
               </td>
               <td class="table-cell">
                 <div class="flex items-center gap-2">
-                  <div :class="['w-3 h-3 rounded-full', getColorClass(task.color_id)]"></div>
+                  <div :class="['w-3 h-3 rounded-full', getTaskColorDotClass(task.color_id)]"></div>
                   <span class="font-medium text-content">{{ task.title }}</span>
                 </div>
               </td>
@@ -275,13 +251,13 @@ const handleSearchSelect = (task: Task) => {
               </td>
               <td class="table-cell">
                 <span
-                  :class="isOverdue(task) ? 'text-error font-medium' : 'text-content-secondary'"
+                  :class="isTaskOverdue(task.date_due, task.is_active) ? 'text-error font-medium' : 'text-content-secondary'"
                 >
-                  {{ formatDate(task.date_due) }}
+                  {{ formatTaskDate(task.date_due) }}
                 </span>
               </td>
               <td class="table-cell text-content-secondary">
-                {{ formatDate(task.date_creation) }}
+                {{ formatTaskDate(task.date_creation) }}
               </td>
               <td class="table-cell">
                 <span

--- a/src/views/ProjectActivityView.vue
+++ b/src/views/ProjectActivityView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, watch, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useBoardStore } from '@/stores/board'
 import { useNotificationsStore } from '@/stores/notifications'
@@ -25,23 +25,23 @@ const activities = ref<Activity[]>([])
 const error = ref<string | null>(null)
 
 const eventLabels: Record<string, string> = {
-  'task.create': '建立任務',
-  'task.update': '更新任務',
-  'task.close': '關閉任務',
-  'task.open': '開啟任務',
-  'task.move.column': '移動任務欄位',
-  'task.move.swimlane': '移動任務泳道',
-  'task.move.position': '調整任務位置',
-  'task.assignee_change': '變更指派人',
-  'comment.create': '新增評論',
-  'comment.update': '更新評論',
-  'comment.delete': '刪除評論',
-  'subtask.create': '新增子任務',
-  'subtask.update': '更新子任務',
-  'subtask.delete': '刪除子任務',
-  'task_file.create': '上傳附件',
-  'task_internal_link.create_update': '建立任務連結',
-  'task_internal_link.delete': '刪除任務連結'
+  'task.create': '建立了任務',
+  'task.update': '更新了任務',
+  'task.close': '關閉了任務',
+  'task.open': '重新開啟了任務',
+  'task.move.column': '移動了任務至',
+  'task.move.swimlane': '將任務移至泳道',
+  'task.move.position': '調整了任務位置',
+  'task.assignee_change': '變更了任務指派人',
+  'comment.create': '發表了評論於',
+  'comment.update': '更新了評論於',
+  'comment.delete': '刪除了評論於',
+  'subtask.create': '新增了子任務',
+  'subtask.update': '更新了子任務',
+  'subtask.delete': '刪除了子任務',
+  'task_file.create': '上傳了附件至',
+  'task_internal_link.create_update': '建立了任務連結',
+  'task_internal_link.delete': '刪除了任務連結'
 }
 
 watch(() => route.params.id, async (newId) => {
@@ -59,13 +59,10 @@ const loadData = async () => {
   isLoading.value = true
   error.value = null
   try {
-    // Load project info if not loaded
     if (!boardStore.project || boardStore.project.id !== projectId.value) {
       await boardStore.fetchBoard(projectId.value)
     }
-    // Load project activities
     await notificationsStore.fetchActivities()
-    // Filter activities for this project
     activities.value = notificationsStore.activities.filter(
       a => a.project_id === projectId.value
     )
@@ -93,7 +90,13 @@ const formatDate = (timestamp: number): string => {
   if (diffHours < 24) return `${diffHours} 小時前`
   if (diffDays < 7) return `${diffDays} 天前`
 
-  return date.toLocaleDateString('zh-TW')
+  return date.toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
 }
 
 const getTaskTitle = (activity: Activity): string => {
@@ -102,6 +105,44 @@ const getTaskTitle = (activity: Activity): string => {
     if (task.title) return task.title
   }
   return activity.task_id ? `#${activity.task_id}` : ''
+}
+
+const getAuthorName = (activity: Activity): string => {
+  return activity.author_name || activity.author_username || '未知使用者'
+}
+
+const getAuthorInitial = (activity: Activity): string => {
+  const name = getAuthorName(activity)
+  return name.charAt(0).toUpperCase()
+}
+
+const getAssigneeName = (activity: Activity): string | null => {
+  if (activity.data?.task && typeof activity.data.task === 'object') {
+    const task = activity.data.task as { assignee_name?: string; assignee_username?: string }
+    return task.assignee_name || task.assignee_username || null
+  }
+  return null
+}
+
+const getColumnName = (activity: Activity): string | null => {
+  if (activity.data?.task && typeof activity.data.task === 'object') {
+    const task = activity.data.task as { column_title?: string }
+    return task.column_title || null
+  }
+  return null
+}
+
+const getCommentContent = (activity: Activity): string | null => {
+  if (activity.data?.comment && typeof activity.data.comment === 'object') {
+    const comment = activity.data.comment as { comment?: string }
+    if (comment.comment) {
+      // Truncate to 100 chars
+      return comment.comment.length > 100
+        ? comment.comment.substring(0, 100) + '...'
+        : comment.comment
+    }
+  }
+  return null
 }
 
 const handleActivityClick = (activity: Activity) => {
@@ -124,82 +165,152 @@ const handleSearchSelect = (task: Task) => {
 }
 
 const getEventIcon = (eventName: string): string => {
-  if (eventName.startsWith('task.create')) return 'plus'
-  if (eventName.startsWith('task.close')) return 'check'
-  if (eventName.startsWith('task.open')) return 'refresh'
-  if (eventName.startsWith('task.move')) return 'arrow'
+  if (eventName.startsWith('task.create')) return 'plus-circle'
+  if (eventName.startsWith('task.close')) return 'check-circle'
+  if (eventName.startsWith('task.open')) return 'rotate'
+  if (eventName.startsWith('task.move')) return 'arrow-right'
+  if (eventName.startsWith('task.assignee')) return 'user'
   if (eventName.startsWith('comment')) return 'chat'
-  if (eventName.startsWith('subtask')) return 'list'
-  if (eventName.startsWith('task_file')) return 'attachment'
+  if (eventName.startsWith('subtask')) return 'list-check'
+  if (eventName.startsWith('task_file')) return 'paperclip'
   if (eventName.startsWith('task_internal_link')) return 'link'
-  return 'activity'
+  if (eventName.startsWith('task.update')) return 'pencil'
+  return 'bolt'
 }
+
+const getEventIconColor = (eventName: string): string => {
+  if (eventName.startsWith('task.create')) return 'text-success bg-success/10'
+  if (eventName.startsWith('task.close')) return 'text-info bg-info/10'
+  if (eventName.startsWith('task.open')) return 'text-warning bg-warning/10'
+  if (eventName.startsWith('comment')) return 'text-accent bg-accent/10'
+  return 'text-content-secondary bg-surface-tertiary'
+}
+
+// Group activities by date
+const groupedActivities = computed(() => {
+  const groups: { date: string; activities: Activity[] }[] = []
+  const dateMap = new Map<string, Activity[]>()
+
+  for (const activity of activities.value) {
+    const date = new Date(activity.date_creation * 1000)
+    const dateKey = date.toLocaleDateString('zh-TW', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+
+    if (!dateMap.has(dateKey)) {
+      dateMap.set(dateKey, [])
+    }
+    dateMap.get(dateKey)!.push(activity)
+  }
+
+  for (const [date, acts] of dateMap) {
+    groups.push({ date, activities: acts })
+  }
+
+  return groups
+})
 </script>
 
 <template>
-  <div class="p-6">
-    <div class="max-w-4xl mx-auto">
+  <div class="h-full flex flex-col bg-surface-secondary overflow-auto">
+    <div class="p-6">
       <!-- Loading -->
       <div v-if="isLoading" class="flex justify-center py-12">
         <ph-icon icon="spinner" class="animate-spin h-8 w-8 text-accent" />
       </div>
 
       <!-- Error -->
-      <div v-else-if="error" class="bg-error/10 border border-error/20 rounded-lg p-4 text-error">
+      <div v-else-if="error" class="bg-error/10 border border-error/20 rounded-lg p-4 text-error max-w-2xl mx-auto">
         {{ error }}
         <button @click="loadData" class="ml-4 underline">重試</button>
       </div>
 
-      <!-- Activities -->
-      <div v-else class="space-y-4">
-        <div
-          v-for="activity in activities"
-          :key="activity.id"
-          @click="handleActivityClick(activity)"
-          class="bg-surface rounded-lg border border-edge p-4 cursor-pointer hover:bg-surface-hover transition-colors"
-        >
-          <div class="flex items-start gap-4">
-            <!-- Icon -->
-            <div class="flex-shrink-0 w-10 h-10 rounded-full bg-accent/10 flex items-center justify-center text-accent">
-              <!-- Plus Icon -->
-              <ph-icon v-if="getEventIcon(activity.event_name) === 'plus'" icon="plus" class="w-5 h-5" />
-              <!-- Check Icon -->
-              <ph-icon v-else-if="getEventIcon(activity.event_name) === 'check'" icon="check" class="w-5 h-5" />
-              <!-- Refresh Icon -->
-              <ph-icon v-else-if="getEventIcon(activity.event_name) === 'refresh'" icon="rotate" class="w-5 h-5" />
-              <!-- Arrow Icon -->
-              <ph-icon v-else-if="getEventIcon(activity.event_name) === 'arrow'" icon="arrow-right" class="w-5 h-5" />
-              <!-- Chat Icon -->
-              <ph-icon v-else-if="getEventIcon(activity.event_name) === 'chat'" icon="comment" class="w-5 h-5" />
-              <!-- List Icon -->
-              <ph-icon v-else-if="getEventIcon(activity.event_name) === 'list'" icon="list-check" class="w-5 h-5" />
-              <!-- Attachment Icon -->
-              <ph-icon v-else-if="getEventIcon(activity.event_name) === 'attachment'" icon="paperclip" class="w-5 h-5" />
-              <!-- Link Icon -->
-              <ph-icon v-else-if="getEventIcon(activity.event_name) === 'link'" icon="link" class="w-5 h-5" />
-              <!-- Default Activity Icon -->
-              <ph-icon v-else icon="bolt" class="w-5 h-5" />
-            </div>
-
-            <!-- Content -->
-            <div class="flex-1 min-w-0">
-              <p class="text-content">
-                <span class="font-medium">{{ getEventLabel(activity.event_name) }}</span>
-                <span v-if="getTaskTitle(activity)" class="text-content-secondary">
-                  : {{ getTaskTitle(activity) }}
-                </span>
-              </p>
-              <p class="text-sm text-content-tertiary mt-1">
-                {{ formatDate(activity.date_creation) }}
-              </p>
-            </div>
-          </div>
-        </div>
-
+      <!-- Activities Timeline -->
+      <div v-else class="max-w-3xl mx-auto">
         <!-- Empty State -->
-        <div v-if="activities.length === 0" class="bg-surface rounded-lg border border-edge p-12 text-center">
+        <div v-if="activities.length === 0" class="card p-12 text-center">
           <ph-icon icon="bolt" class="w-16 h-16 mx-auto mb-4 text-content-tertiary" />
           <p class="text-content-secondary">沒有近期活動</p>
+        </div>
+
+        <!-- Grouped Activities -->
+        <div v-else class="space-y-8">
+          <div v-for="group in groupedActivities" :key="group.date">
+            <!-- Date Header -->
+            <div class="flex items-center gap-4 mb-4">
+              <div class="h-px flex-1 bg-edge"></div>
+              <span class="text-sm font-medium text-content-tertiary px-2">{{ group.date }}</span>
+              <div class="h-px flex-1 bg-edge"></div>
+            </div>
+
+            <!-- Activities for this date -->
+            <div class="space-y-3">
+              <div
+                v-for="activity in group.activities"
+                :key="activity.id"
+                @click="handleActivityClick(activity)"
+                class="card p-4 cursor-pointer hover:bg-surface-hover transition-colors"
+              >
+                <div class="flex gap-4">
+                  <!-- Icon -->
+                  <div
+                    :class="[
+                      'flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center',
+                      getEventIconColor(activity.event_name)
+                    ]"
+                  >
+                    <ph-icon :icon="getEventIcon(activity.event_name)" class="w-5 h-5" />
+                  </div>
+
+                  <!-- Content -->
+                  <div class="flex-1 min-w-0">
+                    <!-- Main info line -->
+                    <p class="text-content">
+                      <span class="font-semibold">{{ getAuthorName(activity) }}</span>
+                      <span class="text-content-secondary"> {{ getEventLabel(activity.event_name) }} </span>
+                      <span v-if="getTaskTitle(activity)" class="font-medium text-accent">
+                        {{ getTaskTitle(activity) }}
+                      </span>
+                    </p>
+
+                    <!-- Additional context -->
+                    <div class="mt-1 text-sm text-content-tertiary space-y-0.5">
+                      <!-- Column info for move events -->
+                      <p v-if="activity.event_name === 'task.move.column' && getColumnName(activity)">
+                        <ph-icon icon="arrow-right" class="w-3.5 h-3.5 inline mr-1" />
+                        欄位：{{ getColumnName(activity) }}
+                      </p>
+
+                      <!-- Assignee info -->
+                      <p v-if="activity.event_name === 'task.assignee_change' && getAssigneeName(activity)">
+                        <ph-icon icon="user" class="w-3.5 h-3.5 inline mr-1" />
+                        指派給：{{ getAssigneeName(activity) }}
+                      </p>
+
+                      <!-- Comment preview -->
+                      <p v-if="activity.event_name === 'comment.create' && getCommentContent(activity)" class="italic">
+                        「{{ getCommentContent(activity) }}」
+                      </p>
+                    </div>
+
+                    <!-- Timestamp -->
+                    <p class="text-xs text-content-tertiary mt-2">
+                      {{ formatDate(activity.date_creation) }}
+                    </p>
+                  </div>
+
+                  <!-- Author avatar -->
+                  <div class="flex-shrink-0">
+                    <div class="w-8 h-8 rounded-full bg-accent/20 flex items-center justify-center text-accent text-sm font-medium">
+                      {{ getAuthorInitial(activity) }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/views/ProjectActivityView.vue
+++ b/src/views/ProjectActivityView.vue
@@ -139,14 +139,6 @@ const getEventIcon = (eventName: string): string => {
 <template>
   <div class="p-6">
     <div class="max-w-4xl mx-auto">
-      <!-- Header -->
-      <div class="mb-6">
-        <h1 class="text-2xl font-bold text-content">專案動態</h1>
-        <p v-if="boardStore.project" class="text-content-secondary mt-1">
-          {{ boardStore.project.name }} 的最近活動
-        </p>
-      </div>
-
       <!-- Loading -->
       <div v-if="isLoading" class="flex justify-center py-12">
         <ph-icon icon="spinner" class="animate-spin h-8 w-8 text-accent" />

--- a/src/views/ProjectActivityView.vue
+++ b/src/views/ProjectActivityView.vue
@@ -99,50 +99,52 @@ const formatDate = (timestamp: number): string => {
   })
 }
 
-const getTaskTitle = (activity: Activity): string => {
+// Helper to safely extract nested data from activity
+function getActivityTaskData(activity: Activity): Record<string, unknown> | null {
   if (activity.data?.task && typeof activity.data.task === 'object') {
-    const task = activity.data.task as { title?: string }
-    if (task.title) return task.title
+    return activity.data.task as Record<string, unknown>
   }
+  return null
+}
+
+function getActivityCommentData(activity: Activity): Record<string, unknown> | null {
+  if (activity.data?.comment && typeof activity.data.comment === 'object') {
+    return activity.data.comment as Record<string, unknown>
+  }
+  return null
+}
+
+function getTaskTitle(activity: Activity): string {
+  const task = getActivityTaskData(activity)
+  if (task?.title && typeof task.title === 'string') return task.title
   return activity.task_id ? `#${activity.task_id}` : ''
 }
 
-const getAuthorName = (activity: Activity): string => {
+function getAuthorName(activity: Activity): string {
   return activity.author_name || activity.author_username || '未知使用者'
 }
 
-const getAuthorInitial = (activity: Activity): string => {
-  const name = getAuthorName(activity)
-  return name.charAt(0).toUpperCase()
+function getAuthorInitial(activity: Activity): string {
+  return getAuthorName(activity).charAt(0).toUpperCase()
 }
 
-const getAssigneeName = (activity: Activity): string | null => {
-  if (activity.data?.task && typeof activity.data.task === 'object') {
-    const task = activity.data.task as { assignee_name?: string; assignee_username?: string }
-    return task.assignee_name || task.assignee_username || null
-  }
-  return null
+function getAssigneeName(activity: Activity): string | null {
+  const task = getActivityTaskData(activity)
+  if (!task) return null
+  const name = task.assignee_name || task.assignee_username
+  return typeof name === 'string' ? name : null
 }
 
-const getColumnName = (activity: Activity): string | null => {
-  if (activity.data?.task && typeof activity.data.task === 'object') {
-    const task = activity.data.task as { column_title?: string }
-    return task.column_title || null
-  }
-  return null
+function getColumnName(activity: Activity): string | null {
+  const task = getActivityTaskData(activity)
+  return task?.column_title && typeof task.column_title === 'string' ? task.column_title : null
 }
 
-const getCommentContent = (activity: Activity): string | null => {
-  if (activity.data?.comment && typeof activity.data.comment === 'object') {
-    const comment = activity.data.comment as { comment?: string }
-    if (comment.comment) {
-      // Truncate to 100 chars
-      return comment.comment.length > 100
-        ? comment.comment.substring(0, 100) + '...'
-        : comment.comment
-    }
-  }
-  return null
+function getCommentContent(activity: Activity): string | null {
+  const comment = getActivityCommentData(activity)
+  if (!comment?.comment || typeof comment.comment !== 'string') return null
+  const content = comment.comment
+  return content.length > 100 ? content.substring(0, 100) + '...' : content
 }
 
 const handleActivityClick = (activity: Activity) => {
@@ -164,25 +166,38 @@ const handleSearchSelect = (task: Task) => {
   emit('close-search-modal')
 }
 
-const getEventIcon = (eventName: string): string => {
-  if (eventName.startsWith('task.create')) return 'plus-circle'
-  if (eventName.startsWith('task.close')) return 'check-circle'
-  if (eventName.startsWith('task.open')) return 'rotate'
-  if (eventName.startsWith('task.move')) return 'arrow-right'
-  if (eventName.startsWith('task.assignee')) return 'user'
-  if (eventName.startsWith('comment')) return 'chat'
-  if (eventName.startsWith('subtask')) return 'list-check'
-  if (eventName.startsWith('task_file')) return 'paperclip'
-  if (eventName.startsWith('task_internal_link')) return 'link'
-  if (eventName.startsWith('task.update')) return 'pencil'
+// Event icon and color mappings
+const eventIconMap: Record<string, string> = {
+  'task.create': 'plus-circle',
+  'task.close': 'check-circle',
+  'task.open': 'rotate',
+  'task.move': 'arrow-right',
+  'task.assignee': 'user',
+  'task.update': 'pencil',
+  'comment': 'chat',
+  'subtask': 'list-check',
+  'task_file': 'paperclip',
+  'task_internal_link': 'link'
+}
+
+const eventColorMap: Record<string, string> = {
+  'task.create': 'text-success bg-success/10',
+  'task.close': 'text-info bg-info/10',
+  'task.open': 'text-warning bg-warning/10',
+  'comment': 'text-accent bg-accent/10'
+}
+
+function getEventIcon(eventName: string): string {
+  for (const [prefix, icon] of Object.entries(eventIconMap)) {
+    if (eventName.startsWith(prefix)) return icon
+  }
   return 'bolt'
 }
 
-const getEventIconColor = (eventName: string): string => {
-  if (eventName.startsWith('task.create')) return 'text-success bg-success/10'
-  if (eventName.startsWith('task.close')) return 'text-info bg-info/10'
-  if (eventName.startsWith('task.open')) return 'text-warning bg-warning/10'
-  if (eventName.startsWith('comment')) return 'text-accent bg-accent/10'
+function getEventIconColor(eventName: string): string {
+  for (const [prefix, color] of Object.entries(eventColorMap)) {
+    if (eventName.startsWith(prefix)) return color
+  }
   return 'text-content-secondary bg-surface-tertiary'
 }
 

--- a/src/views/ProjectAnalyticsView.vue
+++ b/src/views/ProjectAnalyticsView.vue
@@ -159,7 +159,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { useAnalyticsStore } from '@/stores/analytics'
 import { useBoardStore } from '@/stores/board'
 import { useMembersStore } from '@/stores/members'
-import { useProjectsStore } from '@/stores/projects'
 import SearchModal from '@/components/SearchModal.vue'
 import type { Task } from '@/types'
 
@@ -176,7 +175,6 @@ const router = useRouter()
 const analyticsStore = useAnalyticsStore()
 const boardStore = useBoardStore()
 const membersStore = useMembersStore()
-const projectsStore = useProjectsStore()
 
 const projectId = computed(() => Number(route.params.id))
 const isLoading = ref(true)

--- a/src/views/ProjectAnalyticsView.vue
+++ b/src/views/ProjectAnalyticsView.vue
@@ -2,11 +2,6 @@
   <div class="h-full overflow-auto bg-surface-secondary">
     <!-- Main Content -->
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <!-- Page Title -->
-      <div class="mb-6">
-        <h1 class="text-2xl font-bold text-content">專案分析</h1>
-        <p class="text-content-secondary mt-1">{{ projectName }}</p>
-      </div>
       <!-- Loading State -->
       <div v-if="isLoading" class="flex justify-center py-12">
         <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-accent"></div>
@@ -184,7 +179,6 @@ const membersStore = useMembersStore()
 const projectsStore = useProjectsStore()
 
 const projectId = computed(() => Number(route.params.id))
-const projectName = ref('')
 const isLoading = ref(true)
 const error = ref<string | null>(null)
 
@@ -279,12 +273,6 @@ async function loadAnalytics() {
   error.value = null
 
   try {
-    await projectsStore.fetchProjects()
-    const project = projectsStore.getProjectById(projectId.value)
-    if (project) {
-      projectName.value = project.name
-    }
-
     await Promise.all([
       analyticsStore.fetchProjectActivity(projectId.value),
       boardStore.fetchBoard(projectId.value),

--- a/src/views/ProjectOverviewView.vue
+++ b/src/views/ProjectOverviewView.vue
@@ -15,12 +15,8 @@
 
       <!-- Content -->
       <div v-else class="max-w-6xl mx-auto px-6 py-6 animate-fadeIn">
-      <!-- Project Title & Progress Section -->
+      <!-- Progress Section -->
       <section class="mb-6">
-        <div class="mb-4">
-          <h1 class="text-2xl font-bold text-content">{{ project?.name || '專案總覽' }}</h1>
-          <p class="text-sm text-content-tertiary mt-1">專案總覽與進度追蹤</p>
-        </div>
         <div class="flex items-center justify-between mb-3">
           <h2 class="text-xs font-semibold text-content-tertiary uppercase tracking-wider">任務進度</h2>
           <span class="text-sm text-content-secondary">共 {{ totalTasks }} 項任務</span>

--- a/src/views/ProjectSettingsView.vue
+++ b/src/views/ProjectSettingsView.vue
@@ -105,11 +105,6 @@ const handleSearchSelect = (task: Task) => {
 <template>
   <div class="h-full overflow-auto bg-surface-secondary">
     <main class="mx-auto max-w-2xl px-4 py-6">
-      <!-- Page Title -->
-      <div class="mb-6">
-        <h1 class="text-2xl font-bold text-content">專案設定</h1>
-        <p class="text-content-secondary mt-1">{{ currentProject?.name }}</p>
-      </div>
       <!-- Loading -->
       <div v-if="isLoading" class="flex items-center justify-center py-12">
         <ph-icon icon="spinner" class="animate-spin h-8 w-8 text-accent" />


### PR DESCRIPTION
## Summary

- 新增「系統管理」功能，僅限 admin 使用者存取
- 實作四個管理頁面：系統狀態、系統設定、使用者管理、群組管理
- 將 `getKanproBridgePlugin` API 更名為 `getKanproBridgeStatus`

## Changes

### 新增檔案
- `src/stores/system.ts` - 系統狀態 store，管理 Kanboard 伺服器和 KanproBridge 外掛狀態
- `src/views/AdminStatusView.vue` - 系統狀態頁面，左右佈局顯示伺服器資訊和外掛模組狀態
- `src/views/AdminSettingsView.vue` - 系統設定頁面，包含連線和介面設定
- `src/__tests__/system-store.test.ts` - System store 單元測試 (18 個測試案例)
- `docs/plans/2026-01-22-admin-system-management-design.md` - 設計文件

### 修改檔案
- `src/router/index.ts` - 新增 admin 路由 (/admin/*) 和 `requiresAdmin` 權限守衛
- `src/components/header/AppHeader.vue` - 新增 admin 導航列 (與專案導航列相同風格)
- `src/components/header/UserDropdown.vue` - 新增「系統管理」選項 (僅 admin 可見)
- `src/services/api/jwt.ts` - API 方法更名 `getKanproBridgePlugin` → `getKanproBridgeStatus`

## Test Plan

- [x] 單元測試：system store 18 個測試案例全部通過
- [x] 實機測試：admin 帳號登入，驗證「系統管理」選項正確顯示
- [x] 實機測試：系統狀態頁面正確顯示 Kanboard 版本、時區、連線狀態
- [x] 實機測試：系統狀態頁面正確顯示 KanproBridge 外掛版本和模組狀態
- [x] 實機測試：四個 admin 頁面導航正常
- [x] 實機測試：非 admin 帳號登入，確認「系統管理」選項不顯示
- [x] 實機測試：非 admin 帳號直接訪問 /admin 會被導向首頁

Closes #71