### PR TITLE
feat(project): 新增專案完整建立頁面與燈箱展開功能

### DIFF
--- a/src/__tests__/CreateProjectModal.test.ts
+++ b/src/__tests__/CreateProjectModal.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import CreateProjectModal from '@/components/CreateProjectModal.vue'
+import { useProjectDraftStore } from '@/stores/projectDraft'
+import { useAuthStore } from '@/stores/auth'
+
+// Mock fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Create a mock router
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', component: { template: '<div>Home</div>' } },
+    { path: '/projects/new', name: 'project-create', component: { template: '<div>Create</div>' } }
+  ]
+})
+
+// Mock PhIcon component
+const PhIcon = {
+  name: 'PhIcon',
+  props: ['icon'],
+  template: '<span :data-icon="icon"></span>'
+}
+
+describe('CreateProjectModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockFetch.mockReset()
+
+    // Setup auth store
+    const authStore = useAuthStore()
+    authStore._setTestCredentials({
+      apiUrl: 'http://localhost/jsonrpc.php',
+      username: 'admin',
+      password: 'admin'
+    })
+
+    // Mock users API response
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        jsonrpc: '2.0',
+        id: 1,
+        result: []
+      })
+    })
+  })
+
+  function mountModal(props = { isOpen: true }) {
+    return mount(CreateProjectModal, {
+      props,
+      global: {
+        plugins: [router],
+        stubs: {
+          Teleport: true,
+          PhIcon,
+          UserAvatar: true
+        }
+      }
+    })
+  }
+
+  describe('expand button', () => {
+    it('should render expand button in header', () => {
+      const wrapper = mountModal()
+      const expandButton = wrapper.find('[data-testid="expand-button"]')
+
+      expect(expandButton.exists()).toBe(true)
+    })
+
+    it('should have arrows-out icon', () => {
+      const wrapper = mountModal()
+      const expandButton = wrapper.find('[data-testid="expand-button"]')
+      const icon = expandButton.find('[data-icon="arrows-out"]')
+
+      expect(icon.exists()).toBe(true)
+    })
+
+    it('should navigate to /projects/new on click', async () => {
+      const wrapper = mountModal()
+      const expandButton = wrapper.find('[data-testid="expand-button"]')
+
+      await expandButton.trigger('click')
+      await flushPromises()
+
+      expect(router.currentRoute.value.path).toBe('/projects/new')
+    })
+
+    it('should emit close event on expand', async () => {
+      const wrapper = mountModal()
+      const expandButton = wrapper.find('[data-testid="expand-button"]')
+
+      await expandButton.trigger('click')
+
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    it('should save draft data to store before expanding', async () => {
+      const wrapper = mountModal()
+      const draftStore = useProjectDraftStore()
+
+      // Fill in form data
+      const nameInput = wrapper.find('#project-name')
+      await nameInput.setValue('Test Project')
+
+      const descInput = wrapper.find('#project-description')
+      await descInput.setValue('Test Description')
+
+      const expandButton = wrapper.find('[data-testid="expand-button"]')
+      await expandButton.trigger('click')
+
+      expect(draftStore.draft.name).toBe('Test Project')
+      expect(draftStore.draft.description).toBe('Test Description')
+    })
+
+    it('should save advanced settings to store before expanding', async () => {
+      const wrapper = mountModal()
+      const draftStore = useProjectDraftStore()
+
+      // Fill in basic data
+      const nameInput = wrapper.find('#project-name')
+      await nameInput.setValue('Test Project')
+
+      // Toggle advanced settings
+      const advancedToggle = wrapper.find('button[type="button"]')
+      await advancedToggle.trigger('click')
+
+      // Fill in start date
+      const startDateInput = wrapper.find('#project-start-date')
+      if (startDateInput.exists()) {
+        await startDateInput.setValue('2025-01-01')
+      }
+
+      const expandButton = wrapper.find('[data-testid="expand-button"]')
+      await expandButton.trigger('click')
+
+      expect(draftStore.draft.name).toBe('Test Project')
+      expect(draftStore.draft.startDate).toBe('2025-01-01')
+    })
+  })
+
+  describe('form fields', () => {
+    it('should render project name input', () => {
+      const wrapper = mountModal()
+      const nameInput = wrapper.find('#project-name')
+
+      expect(nameInput.exists()).toBe(true)
+    })
+
+    it('should render description textarea', () => {
+      const wrapper = mountModal()
+      const descInput = wrapper.find('#project-description')
+
+      expect(descInput.exists()).toBe(true)
+    })
+
+    it('should render identifier input', () => {
+      const wrapper = mountModal()
+      const identifierInput = wrapper.find('#project-identifier')
+
+      expect(identifierInput.exists()).toBe(true)
+    })
+  })
+})

--- a/src/__tests__/ProjectCreateView.test.ts
+++ b/src/__tests__/ProjectCreateView.test.ts
@@ -69,11 +69,6 @@ describe('ProjectCreateView', () => {
   }
 
   describe('rendering', () => {
-    it('should render page title', () => {
-      const wrapper = mountView()
-      expect(wrapper.find('h1').text()).toBe('建立新專案')
-    })
-
     it('should render create button', () => {
       const wrapper = mountView()
       const createBtn = wrapper.find('button.btn-primary')

--- a/src/__tests__/ProjectCreateView.test.ts
+++ b/src/__tests__/ProjectCreateView.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import ProjectCreateView from '@/views/ProjectCreateView.vue'
+import { useProjectDraftStore } from '@/stores/projectDraft'
+import { useAuthStore } from '@/stores/auth'
+import { useProjectsStore } from '@/stores/projects'
+
+// Mock fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Create a mock router
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', component: { template: '<div>Home</div>' } },
+    { path: '/projects/new', name: 'project-create', component: ProjectCreateView },
+    { path: '/projects/:id/board', name: 'project-board', component: { template: '<div>Board</div>' } }
+  ]
+})
+
+// Mock PhIcon component
+const PhIcon = {
+  name: 'PhIcon',
+  props: ['icon'],
+  template: '<span :data-icon="icon"></span>'
+}
+
+describe('ProjectCreateView', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    mockFetch.mockReset()
+
+    // Setup auth store
+    const authStore = useAuthStore()
+    authStore._setTestCredentials({
+      apiUrl: 'http://localhost/jsonrpc.php',
+      username: 'admin',
+      password: 'admin'
+    })
+
+    // Navigate to the create page
+    await router.push('/projects/new')
+    await router.isReady()
+
+    // Default mock for any API call
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        jsonrpc: '2.0',
+        id: 1,
+        result: []
+      })
+    })
+  })
+
+  function mountView() {
+    return mount(ProjectCreateView, {
+      global: {
+        plugins: [router],
+        stubs: {
+          PhIcon,
+          UserAvatar: true
+        }
+      }
+    })
+  }
+
+  describe('rendering', () => {
+    it('should render page title', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('h1').text()).toBe('建立新專案')
+    })
+
+    it('should render create button', () => {
+      const wrapper = mountView()
+      const createBtn = wrapper.find('button.btn-primary')
+      expect(createBtn.text()).toContain('建立專案')
+    })
+
+    it('should render cancel button', () => {
+      const wrapper = mountView()
+      const cancelBtn = wrapper.find('button.btn-secondary')
+      expect(cancelBtn.text()).toBe('取消')
+    })
+
+    it('should render project name input', () => {
+      const wrapper = mountView()
+      const input = wrapper.find('#projectName')
+      expect(input.exists()).toBe(true)
+    })
+
+    it('should render description textarea', () => {
+      const wrapper = mountView()
+      const textarea = wrapper.find('#projectDescription')
+      expect(textarea.exists()).toBe(true)
+    })
+
+    it('should render identifier input', () => {
+      const wrapper = mountView()
+      const input = wrapper.find('#projectIdentifier')
+      expect(input.exists()).toBe(true)
+    })
+  })
+
+  describe('form validation', () => {
+    it('should disable create button when name is empty', () => {
+      const wrapper = mountView()
+      const createBtn = wrapper.find('button.btn-primary')
+      expect((createBtn.element as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    it('should enable create button when name is filled', async () => {
+      const wrapper = mountView()
+      const draftStore = useProjectDraftStore()
+
+      draftStore.updateDraft({ name: 'Test Project' })
+      await wrapper.vm.$nextTick()
+
+      const createBtn = wrapper.find('button.btn-primary')
+      expect((createBtn.element as HTMLButtonElement).disabled).toBe(false)
+    })
+  })
+
+  describe('draft store integration', () => {
+    it('should update draft store when form fields change', async () => {
+      const wrapper = mountView()
+      const draftStore = useProjectDraftStore()
+
+      const nameInput = wrapper.find('#projectName')
+      await nameInput.setValue('New Project')
+
+      expect(draftStore.draft.name).toBe('New Project')
+    })
+
+    it('should load data from draft store on mount', async () => {
+      const draftStore = useProjectDraftStore()
+      draftStore.updateDraft({
+        name: 'Pre-filled Project',
+        description: 'Pre-filled Description'
+      })
+
+      const wrapper = mountView()
+      await wrapper.vm.$nextTick()
+
+      expect((wrapper.find('#projectName').element as HTMLInputElement).value).toBe('Pre-filled Project')
+      expect((wrapper.find('#projectDescription').element as HTMLTextAreaElement).value).toBe('Pre-filled Description')
+    })
+  })
+
+  describe('management sections', () => {
+    it('should render members section', () => {
+      const wrapper = mountView()
+      const membersSection = wrapper.text()
+      expect(membersSection).toContain('成員')
+    })
+
+    it('should render categories section', () => {
+      const wrapper = mountView()
+      const categoriesSection = wrapper.text()
+      expect(categoriesSection).toContain('類別')
+    })
+
+    it('should render columns section', () => {
+      const wrapper = mountView()
+      const columnsSection = wrapper.text()
+      expect(columnsSection).toContain('欄位')
+    })
+
+    it('should render swimlanes section', () => {
+      const wrapper = mountView()
+      const swimlanesSection = wrapper.text()
+      expect(swimlanesSection).toContain('泳道')
+    })
+  })
+
+  describe('category management', () => {
+    it('should add category to cache', async () => {
+      const wrapper = mountView()
+      const draftStore = useProjectDraftStore()
+
+      // Find category name input and add button
+      const inputs = wrapper.findAll('input[placeholder="類別名稱"]')
+      expect(inputs.length).toBeGreaterThan(0)
+
+      const categoryInput = inputs[0]
+      await categoryInput.setValue('Bug')
+
+      // Find the add button in the category section
+      const categorySection = wrapper.findAll('.settings-card')[1]
+      const addBtn = categorySection.find('button.btn-secondary')
+      await addBtn.trigger('click')
+
+      expect(draftStore.cachedCategories).toHaveLength(1)
+      expect(draftStore.cachedCategories[0].name).toBe('Bug')
+    })
+  })
+
+  describe('column management', () => {
+    it('should add column to cache', async () => {
+      const wrapper = mountView()
+      const draftStore = useProjectDraftStore()
+
+      const inputs = wrapper.findAll('input[placeholder="欄位名稱"]')
+      expect(inputs.length).toBeGreaterThan(0)
+
+      const columnInput = inputs[0]
+      await columnInput.setValue('Backlog')
+
+      const columnSection = wrapper.findAll('.settings-card')[2]
+      const addBtn = columnSection.find('button.btn-secondary')
+      await addBtn.trigger('click')
+
+      expect(draftStore.cachedColumns).toHaveLength(1)
+      expect(draftStore.cachedColumns[0].title).toBe('Backlog')
+    })
+  })
+
+  describe('swimlane management', () => {
+    it('should add swimlane to cache', async () => {
+      const wrapper = mountView()
+      const draftStore = useProjectDraftStore()
+
+      const inputs = wrapper.findAll('input[placeholder="泳道名稱"]')
+      expect(inputs.length).toBeGreaterThan(0)
+
+      const swimlaneInput = inputs[0]
+      await swimlaneInput.setValue('Sprint 1')
+
+      const swimlaneSection = wrapper.findAll('.settings-card')[3]
+      const addBtn = swimlaneSection.find('button.btn-secondary')
+      await addBtn.trigger('click')
+
+      expect(draftStore.cachedSwimlanes).toHaveLength(1)
+      expect(draftStore.cachedSwimlanes[0].name).toBe('Sprint 1')
+    })
+  })
+
+  describe('project creation', () => {
+    it('should call createProject API on submit', async () => {
+      const wrapper = mountView()
+      const draftStore = useProjectDraftStore()
+
+      draftStore.updateDraft({ name: 'Test Project' })
+      await wrapper.vm.$nextTick()
+
+      // Mock successful project creation
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: 123 // project ID
+        })
+      })
+
+      const createBtn = wrapper.find('button.btn-primary')
+      await createBtn.trigger('click')
+      await flushPromises()
+
+      // Verify createProject API was called
+      const calls = mockFetch.mock.calls
+      const createProjectCall = calls.find(call => {
+        try {
+          const body = JSON.parse(call[1].body)
+          return body.method === 'createProject'
+        } catch {
+          return false
+        }
+      })
+
+      expect(createProjectCall).toBeDefined()
+      const body = JSON.parse(createProjectCall![1].body)
+      expect(body.params.name).toBe('Test Project')
+    })
+
+    it('should reset draft store after successful creation', async () => {
+      const wrapper = mountView()
+      const draftStore = useProjectDraftStore()
+
+      draftStore.updateDraft({ name: 'Test Project' })
+      draftStore.addCachedCategory({ name: 'Bug' })
+      await wrapper.vm.$nextTick()
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: 123
+        })
+      })
+
+      const createBtn = wrapper.find('button.btn-primary')
+      await createBtn.trigger('click')
+      await flushPromises()
+
+      expect(draftStore.draft.name).toBe('')
+      expect(draftStore.cachedCategories).toHaveLength(0)
+    })
+
+    it('should show error message on creation failure', async () => {
+      const wrapper = mountView()
+      const draftStore = useProjectDraftStore()
+
+      draftStore.updateDraft({ name: 'Test Project' })
+      await wrapper.vm.$nextTick()
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          jsonrpc: '2.0',
+          id: 1,
+          result: false
+        })
+      })
+
+      const createBtn = wrapper.find('button.btn-primary')
+      await createBtn.trigger('click')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('建立專案失敗')
+    })
+  })
+
+  describe('cancel action', () => {
+    it('should reset draft store on cancel', async () => {
+      const wrapper = mountView()
+      const draftStore = useProjectDraftStore()
+
+      draftStore.updateDraft({ name: 'Test Project' })
+      await wrapper.vm.$nextTick()
+
+      const cancelBtn = wrapper.find('button.btn-secondary')
+      await cancelBtn.trigger('click')
+
+      expect(draftStore.draft.name).toBe('')
+    })
+  })
+})

--- a/src/__tests__/project-draft-store.test.ts
+++ b/src/__tests__/project-draft-store.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useProjectDraftStore } from '@/stores/projectDraft'
+
+describe('ProjectDraft Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('initial state', () => {
+    it('should have empty draft', () => {
+      const store = useProjectDraftStore()
+
+      expect(store.draft).toEqual({
+        name: '',
+        description: '',
+        identifier: '',
+        ownerId: null,
+        startDate: '',
+        endDate: '',
+        priorityDefault: undefined,
+        priorityStart: undefined,
+        priorityEnd: undefined,
+        email: '',
+        disablePublicAccess: false
+      })
+    })
+
+    it('should have empty cached members', () => {
+      const store = useProjectDraftStore()
+      expect(store.cachedMembers).toEqual([])
+    })
+
+    it('should have empty cached categories', () => {
+      const store = useProjectDraftStore()
+      expect(store.cachedCategories).toEqual([])
+    })
+
+    it('should have empty cached columns', () => {
+      const store = useProjectDraftStore()
+      expect(store.cachedColumns).toEqual([])
+    })
+
+    it('should have empty cached swimlanes', () => {
+      const store = useProjectDraftStore()
+      expect(store.cachedSwimlanes).toEqual([])
+    })
+
+    it('should not have draft data initially', () => {
+      const store = useProjectDraftStore()
+      expect(store.hasDraftData).toBe(false)
+    })
+  })
+
+  describe('updateDraft', () => {
+    it('should update draft fields', () => {
+      const store = useProjectDraftStore()
+
+      store.updateDraft({
+        name: 'Test Project',
+        description: 'Test Description'
+      })
+
+      expect(store.draft.name).toBe('Test Project')
+      expect(store.draft.description).toBe('Test Description')
+    })
+
+    it('should merge with existing draft', () => {
+      const store = useProjectDraftStore()
+
+      store.updateDraft({ name: 'Project A' })
+      store.updateDraft({ description: 'Description A' })
+
+      expect(store.draft.name).toBe('Project A')
+      expect(store.draft.description).toBe('Description A')
+    })
+
+    it('should set hasDraftData to true when name is filled', () => {
+      const store = useProjectDraftStore()
+
+      store.updateDraft({ name: 'Project' })
+
+      expect(store.hasDraftData).toBe(true)
+    })
+  })
+
+  describe('cached members', () => {
+    it('should add member to cache', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedMember({ userId: 1, role: 'project-member' })
+
+      expect(store.cachedMembers).toHaveLength(1)
+      expect(store.cachedMembers[0]).toEqual({ userId: 1, role: 'project-member' })
+    })
+
+    it('should not add duplicate member', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedMember({ userId: 1, role: 'project-member' })
+      store.addCachedMember({ userId: 1, role: 'project-manager' })
+
+      expect(store.cachedMembers).toHaveLength(1)
+      expect(store.cachedMembers[0].role).toBe('project-manager')
+    })
+
+    it('should remove member from cache', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedMember({ userId: 1, role: 'project-member' })
+      store.addCachedMember({ userId: 2, role: 'project-member' })
+      store.removeCachedMember(1)
+
+      expect(store.cachedMembers).toHaveLength(1)
+      expect(store.cachedMembers[0].userId).toBe(2)
+    })
+  })
+
+  describe('cached categories', () => {
+    it('should add category to cache', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedCategory({ name: 'Bug', color: 'red' })
+
+      expect(store.cachedCategories).toHaveLength(1)
+      expect(store.cachedCategories[0]).toEqual({ name: 'Bug', color: 'red' })
+    })
+
+    it('should remove category from cache by index', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedCategory({ name: 'Bug', color: 'red' })
+      store.addCachedCategory({ name: 'Feature', color: 'blue' })
+      store.removeCachedCategory(0)
+
+      expect(store.cachedCategories).toHaveLength(1)
+      expect(store.cachedCategories[0].name).toBe('Feature')
+    })
+  })
+
+  describe('cached columns', () => {
+    it('should add column to cache', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedColumn({ title: 'Backlog', taskLimit: 0 })
+
+      expect(store.cachedColumns).toHaveLength(1)
+      expect(store.cachedColumns[0]).toEqual({ title: 'Backlog', taskLimit: 0 })
+    })
+
+    it('should update column in cache by index', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedColumn({ title: 'Backlog', taskLimit: 0 })
+      store.updateCachedColumn(0, { title: 'To Do', taskLimit: 5 })
+
+      expect(store.cachedColumns[0]).toEqual({ title: 'To Do', taskLimit: 5 })
+    })
+
+    it('should remove column from cache by index', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedColumn({ title: 'Backlog', taskLimit: 0 })
+      store.addCachedColumn({ title: 'Done', taskLimit: 0 })
+      store.removeCachedColumn(0)
+
+      expect(store.cachedColumns).toHaveLength(1)
+      expect(store.cachedColumns[0].title).toBe('Done')
+    })
+  })
+
+  describe('cached swimlanes', () => {
+    it('should add swimlane to cache', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedSwimlane({ name: 'Sprint 1', description: '' })
+
+      expect(store.cachedSwimlanes).toHaveLength(1)
+      expect(store.cachedSwimlanes[0]).toEqual({ name: 'Sprint 1', description: '' })
+    })
+
+    it('should remove swimlane from cache by index', () => {
+      const store = useProjectDraftStore()
+
+      store.addCachedSwimlane({ name: 'Sprint 1', description: '' })
+      store.addCachedSwimlane({ name: 'Sprint 2', description: '' })
+      store.removeCachedSwimlane(0)
+
+      expect(store.cachedSwimlanes).toHaveLength(1)
+      expect(store.cachedSwimlanes[0].name).toBe('Sprint 2')
+    })
+  })
+
+  describe('resetDraft', () => {
+    it('should reset all draft data', () => {
+      const store = useProjectDraftStore()
+
+      store.updateDraft({ name: 'Project', description: 'Desc' })
+      store.addCachedMember({ userId: 1, role: 'project-member' })
+      store.addCachedCategory({ name: 'Bug', color: 'red' })
+      store.addCachedColumn({ title: 'Backlog', taskLimit: 0 })
+      store.addCachedSwimlane({ name: 'Sprint 1', description: '' })
+
+      store.resetDraft()
+
+      expect(store.draft.name).toBe('')
+      expect(store.draft.description).toBe('')
+      expect(store.cachedMembers).toHaveLength(0)
+      expect(store.cachedCategories).toHaveLength(0)
+      expect(store.cachedColumns).toHaveLength(0)
+      expect(store.cachedSwimlanes).toHaveLength(0)
+      expect(store.hasDraftData).toBe(false)
+    })
+  })
+
+  describe('hasCachedData', () => {
+    it('should return true when has cached members', () => {
+      const store = useProjectDraftStore()
+      store.addCachedMember({ userId: 1, role: 'project-member' })
+      expect(store.hasCachedData).toBe(true)
+    })
+
+    it('should return true when has cached categories', () => {
+      const store = useProjectDraftStore()
+      store.addCachedCategory({ name: 'Bug', color: 'red' })
+      expect(store.hasCachedData).toBe(true)
+    })
+
+    it('should return true when has cached columns', () => {
+      const store = useProjectDraftStore()
+      store.addCachedColumn({ title: 'Backlog', taskLimit: 0 })
+      expect(store.hasCachedData).toBe(true)
+    })
+
+    it('should return true when has cached swimlanes', () => {
+      const store = useProjectDraftStore()
+      store.addCachedSwimlane({ name: 'Sprint 1', description: '' })
+      expect(store.hasCachedData).toBe(true)
+    })
+
+    it('should return false when no cached data', () => {
+      const store = useProjectDraftStore()
+      expect(store.hasCachedData).toBe(false)
+    })
+  })
+})

--- a/src/components/CreateProjectModal.vue
+++ b/src/components/CreateProjectModal.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useProjectsStore, type CreateProjectOptions } from '@/stores/projects'
 import { useUsersStore } from '@/stores/users'
 import { useAuthStore } from '@/stores/auth'
+import { useProjectDraftStore } from '@/stores/projectDraft'
 import UserAvatar from '@/components/UserAvatar.vue'
 import type { User } from '@/types'
 
@@ -15,9 +17,11 @@ const emit = defineEmits<{
   created: [projectId: number]
 }>()
 
+const router = useRouter()
 const projectsStore = useProjectsStore()
 const usersStore = useUsersStore()
 const authStore = useAuthStore()
+const projectDraftStore = useProjectDraftStore()
 
 // === 主區域欄位 ===
 const name = ref('')
@@ -92,6 +96,27 @@ function resetForm() {
 
 function toggleAdvanced() {
   showAdvanced.value = !showAdvanced.value
+}
+
+function handleExpand() {
+  // 儲存目前填寫的資料到 draft store
+  projectDraftStore.updateDraft({
+    name: name.value,
+    description: description.value,
+    identifier: identifier.value,
+    ownerId: ownerId.value,
+    startDate: startDate.value,
+    endDate: endDate.value,
+    priorityDefault: priorityDefault.value,
+    priorityStart: priorityStart.value,
+    priorityEnd: priorityEnd.value,
+    email: projectEmail.value,
+    disablePublicAccess: disablePublicAccess.value
+  })
+
+  // 關閉燈箱並導向專案建立頁
+  emit('close')
+  router.push('/projects/new')
 }
 
 function selectOwner(user: User) {
@@ -201,6 +226,16 @@ onMounted(() => {
                   <span>進階設定</span>
                   <!-- Chevron: > when collapsed, < when expanded -->
                   <ph-icon :icon="showAdvanced ? 'chevron-left' : 'chevron-right'" class="w-3.5 h-3.5" />
+                </button>
+                <!-- Expand to full page button -->
+                <button
+                  type="button"
+                  data-testid="expand-button"
+                  @click="handleExpand"
+                  class="flex items-center gap-1 px-2.5 py-1 text-xs font-medium leading-none rounded transition-colors bg-surface-secondary text-content-tertiary hover:text-content-secondary"
+                  title="展開為完整頁面"
+                >
+                  <ph-icon icon="arrows-out" class="w-3.5 h-3.5" />
                 </button>
               </div>
               <button

--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -23,6 +23,9 @@ const currentProjectName = computed(() => boardStore.project?.name || '')
 // Check if we're in admin context
 const isAdminContext = computed(() => route.path.startsWith('/admin'))
 
+// Check if we're on project create page
+const isProjectCreatePage = computed(() => route.name === 'project-create')
+
 const projectNavItems = computed(() => {
   const id = currentProjectId.value
   if (!id) return []
@@ -82,8 +85,20 @@ function openCreateTask(): void {
 
     <!-- Left side content -->
     <div class="hidden lg:flex items-center gap-1">
-      <!-- Quick Actions (Left side - only when NOT in project or admin context) -->
-      <template v-if="!currentProjectId && !isAdminContext">
+      <!-- Project Create Page Title -->
+      <template v-if="isProjectCreatePage">
+        <div class="flex items-center gap-2 min-w-0">
+          <div class="w-7 h-7 bg-accent/10 rounded-md flex items-center justify-center flex-shrink-0">
+            <ph-icon icon="folder-plus" class="w-4 h-4 text-accent" />
+          </div>
+          <span class="text-base font-semibold text-content">
+            建立新專案
+          </span>
+        </div>
+      </template>
+
+      <!-- Quick Actions (Left side - only when NOT in project, admin context, or project create page) -->
+      <template v-else-if="!currentProjectId && !isAdminContext">
         <!-- Create Project Button -->
         <button
           @click="openCreateProject"
@@ -223,8 +238,8 @@ function openCreateTask(): void {
 
     <!-- Right side content -->
     <div class="hidden lg:flex items-center gap-1">
-      <!-- Quick Actions (Right side - only when IN project context) -->
-      <template v-if="currentProjectId">
+      <!-- Quick Actions (Right side - when IN project context or on project create page) -->
+      <template v-if="currentProjectId || isProjectCreatePage">
         <!-- Create Project Button -->
         <button
           @click="openCreateProject"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -56,6 +56,12 @@ const router = createRouter({
           meta: { sidebarMode: 'global' }
         },
         {
+          path: 'projects/new',
+          name: 'project-create',
+          component: () => import('@/views/ProjectCreateView.vue'),
+          meta: { sidebarMode: 'global' }
+        },
+        {
           path: 'settings',
           name: 'user-settings',
           component: () => import('@/views/UserSettingsView.vue'),

--- a/src/stores/projectDraft.ts
+++ b/src/stores/projectDraft.ts
@@ -1,0 +1,183 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+/**
+ * 專案草稿的基本資訊
+ */
+export interface ProjectDraftInfo {
+  name: string
+  description: string
+  identifier: string
+  ownerId: number | null
+  startDate: string
+  endDate: string
+  priorityDefault: number | undefined
+  priorityStart: number | undefined
+  priorityEnd: number | undefined
+  email: string
+  disablePublicAccess: boolean
+}
+
+/**
+ * 緩存的成員資料
+ */
+export interface CachedMember {
+  userId: number
+  role: 'project-manager' | 'project-member' | 'project-viewer'
+}
+
+/**
+ * 緩存的類別資料
+ */
+export interface CachedCategory {
+  name: string
+  color?: string
+}
+
+/**
+ * 緩存的欄位資料
+ */
+export interface CachedColumn {
+  title: string
+  taskLimit: number
+  description?: string
+}
+
+/**
+ * 緩存的泳道資料
+ */
+export interface CachedSwimlane {
+  name: string
+  description: string
+}
+
+function getDefaultDraft(): ProjectDraftInfo {
+  return {
+    name: '',
+    description: '',
+    identifier: '',
+    ownerId: null,
+    startDate: '',
+    endDate: '',
+    priorityDefault: undefined,
+    priorityStart: undefined,
+    priorityEnd: undefined,
+    email: '',
+    disablePublicAccess: false
+  }
+}
+
+/**
+ * 專案草稿 Store
+ * 用於緩存建立專案頁面的資料，以及從燈箱展開時帶入的資料
+ */
+export const useProjectDraftStore = defineStore('projectDraft', () => {
+  // === 基本資訊 ===
+  const draft = ref<ProjectDraftInfo>(getDefaultDraft())
+
+  // === 緩存的管理資料 ===
+  const cachedMembers = ref<CachedMember[]>([])
+  const cachedCategories = ref<CachedCategory[]>([])
+  const cachedColumns = ref<CachedColumn[]>([])
+  const cachedSwimlanes = ref<CachedSwimlane[]>([])
+
+  // === Computed ===
+  const hasDraftData = computed(() => {
+    return draft.value.name.trim().length > 0
+  })
+
+  const hasCachedData = computed(() => {
+    return (
+      cachedMembers.value.length > 0 ||
+      cachedCategories.value.length > 0 ||
+      cachedColumns.value.length > 0 ||
+      cachedSwimlanes.value.length > 0
+    )
+  })
+
+  // === Draft Actions ===
+  function updateDraft(data: Partial<ProjectDraftInfo>) {
+    draft.value = { ...draft.value, ...data }
+  }
+
+  function resetDraft() {
+    draft.value = getDefaultDraft()
+    cachedMembers.value = []
+    cachedCategories.value = []
+    cachedColumns.value = []
+    cachedSwimlanes.value = []
+  }
+
+  // === Member Actions ===
+  function addCachedMember(member: CachedMember) {
+    const existingIndex = cachedMembers.value.findIndex(m => m.userId === member.userId)
+    if (existingIndex >= 0) {
+      cachedMembers.value[existingIndex] = member
+    } else {
+      cachedMembers.value.push(member)
+    }
+  }
+
+  function removeCachedMember(userId: number) {
+    cachedMembers.value = cachedMembers.value.filter(m => m.userId !== userId)
+  }
+
+  // === Category Actions ===
+  function addCachedCategory(category: CachedCategory) {
+    cachedCategories.value.push(category)
+  }
+
+  function removeCachedCategory(index: number) {
+    cachedCategories.value.splice(index, 1)
+  }
+
+  // === Column Actions ===
+  function addCachedColumn(column: CachedColumn) {
+    cachedColumns.value.push(column)
+  }
+
+  function updateCachedColumn(index: number, column: CachedColumn) {
+    if (index >= 0 && index < cachedColumns.value.length) {
+      cachedColumns.value[index] = column
+    }
+  }
+
+  function removeCachedColumn(index: number) {
+    cachedColumns.value.splice(index, 1)
+  }
+
+  // === Swimlane Actions ===
+  function addCachedSwimlane(swimlane: CachedSwimlane) {
+    cachedSwimlanes.value.push(swimlane)
+  }
+
+  function removeCachedSwimlane(index: number) {
+    cachedSwimlanes.value.splice(index, 1)
+  }
+
+  return {
+    // State
+    draft,
+    cachedMembers,
+    cachedCategories,
+    cachedColumns,
+    cachedSwimlanes,
+
+    // Computed
+    hasDraftData,
+    hasCachedData,
+
+    // Actions
+    updateDraft,
+    resetDraft,
+    addCachedMember,
+    removeCachedMember,
+    addCachedCategory,
+    removeCachedCategory,
+    addCachedColumn,
+    updateCachedColumn,
+    removeCachedColumn,
+    addCachedSwimlane,
+    removeCachedSwimlane
+  }
+})

--- a/src/views/ProjectCreateView.vue
+++ b/src/views/ProjectCreateView.vue
@@ -311,28 +311,6 @@ onUnmounted(() => {
 <template>
   <div class="h-full overflow-auto bg-surface-secondary">
     <main class="w-full px-6 py-6">
-      <!-- Header -->
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-bold text-content">建立新專案</h1>
-        <div class="flex items-center gap-3">
-          <button
-            @click="handleCancel"
-            :disabled="isCreating"
-            class="btn-secondary"
-          >
-            取消
-          </button>
-          <button
-            @click="handleCreate"
-            :disabled="!isValid || isCreating"
-            class="btn-primary"
-          >
-            <ph-icon v-if="isCreating" icon="spinner" class="animate-spin -ml-1 mr-2 h-4 w-4" />
-            {{ isCreating ? '建立中...' : '建立專案' }}
-          </button>
-        </div>
-      </div>
-
       <!-- Error Alert -->
       <div v-if="error" class="alert-error mb-6">
         <div class="flex items-center gap-2">
@@ -571,6 +549,27 @@ onUnmounted(() => {
               </div>
             </div>
           </div>
+        </div>
+
+        <!-- Form Footer with Action Buttons -->
+        <div class="flex justify-end gap-3 px-6 py-4 border-t border-edge bg-surface-secondary/30">
+          <button
+            type="button"
+            @click="handleCancel"
+            :disabled="isCreating"
+            class="btn-secondary"
+          >
+            取消
+          </button>
+          <button
+            type="button"
+            @click="handleCreate"
+            :disabled="!isValid || isCreating"
+            class="btn-primary"
+          >
+            <ph-icon v-if="isCreating" icon="spinner" class="animate-spin -ml-1 mr-2 h-4 w-4" />
+            {{ isCreating ? '建立中...' : '建立專案' }}
+          </button>
         </div>
       </div>
 

--- a/src/views/ProjectCreateView.vue
+++ b/src/views/ProjectCreateView.vue
@@ -1,0 +1,851 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useProjectsStore } from '@/stores/projects'
+import { useUsersStore } from '@/stores/users'
+import { useProjectDraftStore } from '@/stores/projectDraft'
+import { useColumnsStore } from '@/stores/columns'
+import { useCategoriesStore } from '@/stores/categories'
+import { useSwimlanesStore } from '@/stores/swimlanes'
+import { useMembersStore } from '@/stores/members'
+import { useToast } from '@/stores/toast'
+import UserAvatar from '@/components/UserAvatar.vue'
+import type { User } from '@/types'
+
+const router = useRouter()
+const projectsStore = useProjectsStore()
+const usersStore = useUsersStore()
+const draftStore = useProjectDraftStore()
+const columnsStore = useColumnsStore()
+const categoriesStore = useCategoriesStore()
+const swimlanesStore = useSwimlanesStore()
+const membersStore = useMembersStore()
+const toast = useToast()
+
+// === 基本資訊欄位 (綁定到 draft store) ===
+const projectName = computed({
+  get: () => draftStore.draft.name,
+  set: (val) => draftStore.updateDraft({ name: val })
+})
+const projectDescription = computed({
+  get: () => draftStore.draft.description,
+  set: (val) => draftStore.updateDraft({ description: val })
+})
+const projectIdentifier = computed({
+  get: () => draftStore.draft.identifier,
+  set: (val) => draftStore.updateDraft({ identifier: val })
+})
+const ownerId = computed({
+  get: () => draftStore.draft.ownerId,
+  set: (val) => draftStore.updateDraft({ ownerId: val })
+})
+const startDate = computed({
+  get: () => draftStore.draft.startDate,
+  set: (val) => draftStore.updateDraft({ startDate: val })
+})
+const endDate = computed({
+  get: () => draftStore.draft.endDate,
+  set: (val) => draftStore.updateDraft({ endDate: val })
+})
+const priorityDefault = computed({
+  get: () => draftStore.draft.priorityDefault,
+  set: (val) => draftStore.updateDraft({ priorityDefault: val })
+})
+const priorityStart = computed({
+  get: () => draftStore.draft.priorityStart,
+  set: (val) => draftStore.updateDraft({ priorityStart: val })
+})
+const priorityEnd = computed({
+  get: () => draftStore.draft.priorityEnd,
+  set: (val) => draftStore.updateDraft({ priorityEnd: val })
+})
+const projectEmail = computed({
+  get: () => draftStore.draft.email,
+  set: (val) => draftStore.updateDraft({ email: val })
+})
+const disablePublicAccess = computed({
+  get: () => draftStore.draft.disablePublicAccess,
+  set: (val) => draftStore.updateDraft({ disablePublicAccess: val })
+})
+
+// === UI 狀態 ===
+const isCreating = ref(false)
+const error = ref<string | null>(null)
+const ownerSearchQuery = ref('')
+const showOwnerDropdown = ref(false)
+
+// === 管理區塊輸入狀態 ===
+const newMemberUserId = ref<number | null>(null)
+const newMemberRole = ref<'project-manager' | 'project-member' | 'project-viewer'>('project-member')
+const showMemberDropdown = ref(false)
+const memberSearchQuery = ref('')
+
+const newCategoryName = ref('')
+const newCategoryColor = ref('')
+
+const newColumnTitle = ref('')
+const newColumnLimit = ref(0)
+
+const newSwimlaneName = ref('')
+const newSwimlaneDescription = ref('')
+
+// === Computed ===
+const isValid = computed(() => projectName.value.trim().length > 0)
+
+const filteredUsers = computed(() => {
+  const query = ownerSearchQuery.value.toLowerCase()
+  if (!query) return usersStore.activeUsers
+  return usersStore.activeUsers.filter(u =>
+    u.username.toLowerCase().includes(query) ||
+    (u.name?.toLowerCase().includes(query) ?? false)
+  )
+})
+
+const selectedOwner = computed(() => {
+  if (!ownerId.value) return null
+  return usersStore.users.find(u => u.id === ownerId.value) || null
+})
+
+const filteredMemberUsers = computed(() => {
+  const query = memberSearchQuery.value.toLowerCase()
+  const existingIds = draftStore.cachedMembers.map(m => m.userId)
+  let users = usersStore.activeUsers.filter(u => !existingIds.includes(u.id))
+  if (query) {
+    users = users.filter(u =>
+      u.username.toLowerCase().includes(query) ||
+      (u.name?.toLowerCase().includes(query) ?? false)
+    )
+  }
+  return users
+})
+
+// === Functions ===
+function selectOwner(user: User) {
+  ownerId.value = user.id
+  ownerSearchQuery.value = ''
+  showOwnerDropdown.value = false
+}
+
+function clearOwner() {
+  ownerId.value = null
+  showOwnerDropdown.value = false
+}
+
+function getUserById(userId: number): User | undefined {
+  return usersStore.users.find(u => u.id === userId)
+}
+
+// === 成員管理 ===
+function addMember() {
+  if (!newMemberUserId.value) return
+  draftStore.addCachedMember({
+    userId: newMemberUserId.value,
+    role: newMemberRole.value
+  })
+  newMemberUserId.value = null
+  newMemberRole.value = 'project-member'
+  showMemberDropdown.value = false
+  memberSearchQuery.value = ''
+}
+
+function selectMemberUser(user: User) {
+  newMemberUserId.value = user.id
+  memberSearchQuery.value = ''
+  showMemberDropdown.value = false
+}
+
+function removeMember(userId: number) {
+  draftStore.removeCachedMember(userId)
+}
+
+// === 類別管理 ===
+function addCategory() {
+  if (!newCategoryName.value.trim()) return
+  draftStore.addCachedCategory({
+    name: newCategoryName.value.trim(),
+    color: newCategoryColor.value || undefined
+  })
+  newCategoryName.value = ''
+  newCategoryColor.value = ''
+}
+
+function removeCategory(index: number) {
+  draftStore.removeCachedCategory(index)
+}
+
+// === 欄位管理 ===
+function addColumn() {
+  if (!newColumnTitle.value.trim()) return
+  draftStore.addCachedColumn({
+    title: newColumnTitle.value.trim(),
+    taskLimit: newColumnLimit.value || 0
+  })
+  newColumnTitle.value = ''
+  newColumnLimit.value = 0
+}
+
+function removeColumn(index: number) {
+  draftStore.removeCachedColumn(index)
+}
+
+// === 泳道管理 ===
+function addSwimlane() {
+  if (!newSwimlaneName.value.trim()) return
+  draftStore.addCachedSwimlane({
+    name: newSwimlaneName.value.trim(),
+    description: newSwimlaneDescription.value
+  })
+  newSwimlaneName.value = ''
+  newSwimlaneDescription.value = ''
+}
+
+function removeSwimlane(index: number) {
+  draftStore.removeCachedSwimlane(index)
+}
+
+// === 建立專案 ===
+async function handleCreate() {
+  if (!isValid.value || isCreating.value) return
+
+  isCreating.value = true
+  error.value = null
+
+  try {
+    // Step 1: 建立專案
+    const projectId = await projectsStore.createProject({
+      name: projectName.value.trim(),
+      description: projectDescription.value.trim() || undefined,
+      identifier: projectIdentifier.value.trim() || undefined,
+      owner_id: ownerId.value || undefined,
+      start_date: startDate.value || undefined,
+      end_date: endDate.value || undefined,
+      priority_default: priorityDefault.value,
+      priority_start: priorityStart.value,
+      priority_end: priorityEnd.value,
+      email: projectEmail.value.trim() || undefined,
+      disablePublicAccess: disablePublicAccess.value
+    })
+
+    if (projectId === false) {
+      throw new Error(projectsStore.error || '建立專案失敗')
+    }
+
+    // Step 2: 建立緩存的成員
+    for (const member of draftStore.cachedMembers) {
+      try {
+        await membersStore.addProjectUser(projectId, member.userId, member.role)
+      } catch (err) {
+        console.error('Failed to add member:', err)
+      }
+    }
+
+    // Step 3: 建立緩存的類別
+    for (const category of draftStore.cachedCategories) {
+      try {
+        await categoriesStore.addCategory(projectId, category.name)
+      } catch (err) {
+        console.error('Failed to create category:', err)
+      }
+    }
+
+    // Step 4: 建立緩存的欄位
+    for (const column of draftStore.cachedColumns) {
+      try {
+        await columnsStore.addColumn(projectId, column.title, column.taskLimit)
+      } catch (err) {
+        console.error('Failed to add column:', err)
+      }
+    }
+
+    // Step 5: 建立緩存的泳道
+    for (const swimlane of draftStore.cachedSwimlanes) {
+      try {
+        await swimlanesStore.addSwimlane(projectId, swimlane.name, swimlane.description)
+      } catch (err) {
+        console.error('Failed to add swimlane:', err)
+      }
+    }
+
+    // 清除草稿資料
+    draftStore.resetDraft()
+
+    toast.success('建立成功', '專案已建立')
+    router.push(`/projects/${projectId}/board`)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : '建立專案失敗'
+    toast.error('建立失敗', error.value)
+  } finally {
+    isCreating.value = false
+  }
+}
+
+function handleCancel() {
+  draftStore.resetDraft()
+  router.back()
+}
+
+// 點擊外部關閉下拉選單
+function handleClickOutside(event: MouseEvent) {
+  const target = event.target as HTMLElement
+  if (!target.closest('.owner-dropdown-container')) {
+    showOwnerDropdown.value = false
+  }
+  if (!target.closest('.member-dropdown-container')) {
+    showMemberDropdown.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+  // 載入使用者列表
+  if (usersStore.users.length === 0) {
+    usersStore.fetchAllUsers()
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+</script>
+
+<template>
+  <div class="h-full overflow-auto bg-surface-secondary">
+    <main class="w-full px-6 py-6">
+      <!-- Header -->
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold text-content">建立新專案</h1>
+        <div class="flex items-center gap-3">
+          <button
+            @click="handleCancel"
+            :disabled="isCreating"
+            class="btn-secondary"
+          >
+            取消
+          </button>
+          <button
+            @click="handleCreate"
+            :disabled="!isValid || isCreating"
+            class="btn-primary"
+          >
+            <ph-icon v-if="isCreating" icon="spinner" class="animate-spin -ml-1 mr-2 h-4 w-4" />
+            {{ isCreating ? '建立中...' : '建立專案' }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Error Alert -->
+      <div v-if="error" class="alert-error mb-6">
+        <div class="flex items-center gap-2">
+          <ph-icon icon="warning" class="w-5 h-5" />
+          <span>{{ error }}</span>
+        </div>
+      </div>
+
+      <!-- 專案設定表單 - 雙欄佈局（寬度比 3:2） -->
+      <div class="bg-surface rounded-xl border border-edge overflow-hidden mb-6">
+        <div class="flex">
+          <!-- 左欄 - 基礎欄位（3/5 寬度） -->
+          <div class="w-3/5 p-6 space-y-5">
+            <!-- 專案名稱 -->
+            <div>
+              <label for="projectName" class="block text-sm font-medium text-content-secondary mb-1.5">
+                專案名稱 <span class="text-red-500">*</span>
+              </label>
+              <input
+                id="projectName"
+                v-model="projectName"
+                type="text"
+                class="input"
+                placeholder="輸入專案名稱"
+                :disabled="isCreating"
+              />
+            </div>
+
+            <!-- 專案描述 -->
+            <div>
+              <label for="projectDescription" class="block text-sm font-medium text-content-secondary mb-1.5">
+                描述
+              </label>
+              <textarea
+                id="projectDescription"
+                v-model="projectDescription"
+                rows="4"
+                class="input resize-none"
+                placeholder="輸入專案描述（選填）"
+                :disabled="isCreating"
+              ></textarea>
+            </div>
+
+            <!-- 專案識別碼 -->
+            <div>
+              <label for="projectIdentifier" class="block text-sm font-medium text-content-secondary mb-1.5">
+                專案識別碼
+              </label>
+              <input
+                id="projectIdentifier"
+                v-model="projectIdentifier"
+                type="text"
+                class="input"
+                placeholder="例如：PROJ"
+                :disabled="isCreating"
+              />
+              <p class="mt-1.5 text-xs text-content-tertiary">
+                用於任務編號前綴，如：PROJ-123
+              </p>
+            </div>
+          </div>
+
+          <!-- 右欄 - 進階欄位（2/5 寬度） -->
+          <div class="w-2/5 border-l border-edge bg-surface-secondary/30 p-6 space-y-5">
+            <!-- 擁有者 -->
+            <div class="owner-dropdown-container">
+              <label class="block text-sm font-medium text-content-secondary mb-1.5">
+                擁有者
+              </label>
+              <div class="relative">
+                <button
+                  type="button"
+                  @click="showOwnerDropdown = !showOwnerDropdown"
+                  class="w-full px-3 py-2 bg-surface border border-edge rounded-md text-left flex items-center gap-2 hover:bg-surface-hover transition-colors"
+                  :disabled="isCreating"
+                >
+                  <template v-if="selectedOwner">
+                    <UserAvatar :user="selectedOwner" size="sm" />
+                    <span class="flex-1 truncate text-sm text-content">
+                      {{ selectedOwner.name || selectedOwner.username }}
+                    </span>
+                    <button
+                      type="button"
+                      @click.stop="clearOwner"
+                      class="text-content-tertiary hover:text-content-secondary"
+                    >
+                      <ph-icon icon="xmark" class="w-4 h-4" />
+                    </button>
+                  </template>
+                  <template v-else>
+                    <span class="flex-1 text-sm text-content-tertiary">選擇擁有者（選填）</span>
+                  </template>
+                  <ph-icon icon="chevron-down" class="w-4 h-4 text-content-tertiary" />
+                </button>
+
+                <!-- Owner Dropdown -->
+                <Transition name="dropdown">
+                  <div
+                    v-if="showOwnerDropdown"
+                    class="absolute z-10 w-full mt-1 bg-surface border border-edge rounded-md shadow-lg max-h-48 overflow-y-auto"
+                  >
+                    <div class="p-2 border-b border-edge">
+                      <input
+                        v-model="ownerSearchQuery"
+                        type="text"
+                        placeholder="搜尋使用者..."
+                        class="w-full px-2 py-1 text-sm bg-surface-secondary border border-edge rounded text-content placeholder:text-content-tertiary focus:outline-none focus:ring-1 focus:ring-accent"
+                      />
+                    </div>
+                    <div class="py-1">
+                      <button
+                        v-for="user in filteredUsers"
+                        :key="user.id"
+                        type="button"
+                        @click="selectOwner(user)"
+                        class="w-full px-3 py-2 text-left flex items-center gap-2 hover:bg-surface-hover transition-colors"
+                        :class="{ 'bg-accent/10': ownerId === user.id }"
+                      >
+                        <UserAvatar :user="user" size="sm" />
+                        <div class="flex-1 min-w-0">
+                          <div class="text-sm text-content truncate">{{ user.name || user.username }}</div>
+                          <div class="text-xs text-content-tertiary truncate">@{{ user.username }}</div>
+                        </div>
+                      </button>
+                      <div v-if="filteredUsers.length === 0" class="px-3 py-2 text-sm text-content-tertiary">
+                        找不到使用者
+                      </div>
+                    </div>
+                  </div>
+                </Transition>
+              </div>
+            </div>
+
+            <!-- 日期範圍 -->
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label for="startDate" class="block text-sm font-medium text-content-secondary mb-1.5">
+                  開始日期
+                </label>
+                <input
+                  id="startDate"
+                  v-model="startDate"
+                  type="date"
+                  class="input text-sm"
+                  :disabled="isCreating"
+                />
+              </div>
+              <div>
+                <label for="endDate" class="block text-sm font-medium text-content-secondary mb-1.5">
+                  結束日期
+                </label>
+                <input
+                  id="endDate"
+                  v-model="endDate"
+                  type="date"
+                  class="input text-sm"
+                  :min="startDate"
+                  :disabled="isCreating"
+                />
+              </div>
+            </div>
+
+            <!-- 優先級設定 -->
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label for="priorityDefault" class="block text-sm font-medium text-content-secondary mb-1.5">
+                  預設優先級
+                </label>
+                <input
+                  id="priorityDefault"
+                  v-model.number="priorityDefault"
+                  type="number"
+                  min="0"
+                  class="input text-sm"
+                  placeholder="0"
+                  :disabled="isCreating"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-content-secondary mb-1.5">
+                  優先級範圍
+                </label>
+                <div class="flex items-center gap-1">
+                  <input
+                    v-model.number="priorityStart"
+                    type="number"
+                    min="0"
+                    class="input text-sm flex-1"
+                    placeholder="0"
+                    :disabled="isCreating"
+                  />
+                  <span class="text-content-tertiary text-xs">~</span>
+                  <input
+                    v-model.number="priorityEnd"
+                    type="number"
+                    min="0"
+                    class="input text-sm flex-1"
+                    placeholder="3"
+                    :disabled="isCreating"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <!-- 專案 Email -->
+            <div>
+              <label for="projectEmail" class="block text-sm font-medium text-content-secondary mb-1.5">
+                專案通知 Email
+              </label>
+              <input
+                id="projectEmail"
+                v-model="projectEmail"
+                type="email"
+                class="input text-sm"
+                placeholder="project@example.com"
+                :disabled="isCreating"
+              />
+            </div>
+
+            <!-- 公開存取 -->
+            <div class="flex items-start gap-3 pt-3 border-t border-edge">
+              <input
+                id="disablePublicAccess"
+                v-model="disablePublicAccess"
+                type="checkbox"
+                :disabled="isCreating"
+                class="mt-0.5 w-4 h-4 rounded border-edge text-accent focus:ring-accent focus:ring-offset-0"
+              />
+              <div>
+                <label for="disablePublicAccess" class="text-sm text-content font-medium cursor-pointer">
+                  限制公開存取
+                </label>
+                <p class="text-xs text-content-tertiary mt-0.5">
+                  建立後將自動關閉公開存取功能
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 管理區塊 - 2x2 Grid -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        <!-- 成員管理 -->
+        <div class="settings-card">
+          <div class="px-4 py-3 border-b border-edge">
+            <h3 class="text-base font-semibold text-content">成員</h3>
+            <p class="text-xs text-content-tertiary mt-0.5">專案建立後將自動加入這些成員</p>
+          </div>
+          <div class="p-4 space-y-3">
+            <!-- 新增成員表單 -->
+            <div class="flex gap-2 member-dropdown-container">
+              <div class="relative flex-1">
+                <button
+                  type="button"
+                  @click="showMemberDropdown = !showMemberDropdown"
+                  class="w-full px-3 py-2 bg-surface-secondary border border-edge rounded-md text-left text-sm text-content-tertiary hover:bg-surface-hover transition-colors"
+                >
+                  {{ newMemberUserId ? getUserById(newMemberUserId)?.name || getUserById(newMemberUserId)?.username : '選擇使用者' }}
+                </button>
+                <Transition name="dropdown">
+                  <div
+                    v-if="showMemberDropdown"
+                    class="absolute z-10 w-full mt-1 bg-surface border border-edge rounded-md shadow-lg max-h-48 overflow-y-auto"
+                  >
+                    <div class="p-2 border-b border-edge">
+                      <input
+                        v-model="memberSearchQuery"
+                        type="text"
+                        placeholder="搜尋使用者..."
+                        class="w-full px-2 py-1 text-sm bg-surface-secondary border border-edge rounded text-content placeholder:text-content-tertiary focus:outline-none focus:ring-1 focus:ring-accent"
+                      />
+                    </div>
+                    <div class="py-1">
+                      <button
+                        v-for="user in filteredMemberUsers"
+                        :key="user.id"
+                        type="button"
+                        @click="selectMemberUser(user)"
+                        class="w-full px-3 py-2 text-left flex items-center gap-2 hover:bg-surface-hover transition-colors"
+                      >
+                        <UserAvatar :user="user" size="sm" />
+                        <div class="flex-1 min-w-0">
+                          <div class="text-sm text-content truncate">{{ user.name || user.username }}</div>
+                        </div>
+                      </button>
+                      <div v-if="filteredMemberUsers.length === 0" class="px-3 py-2 text-sm text-content-tertiary">
+                        沒有可新增的使用者
+                      </div>
+                    </div>
+                  </div>
+                </Transition>
+              </div>
+              <select
+                v-model="newMemberRole"
+                class="input text-sm w-32"
+              >
+                <option value="project-manager">管理員</option>
+                <option value="project-member">成員</option>
+                <option value="project-viewer">檢視者</option>
+              </select>
+              <button
+                @click="addMember"
+                :disabled="!newMemberUserId"
+                class="btn-secondary px-3"
+              >
+                <ph-icon icon="plus" class="w-4 h-4" />
+              </button>
+            </div>
+            <!-- 成員列表 -->
+            <div v-if="draftStore.cachedMembers.length > 0" class="space-y-2">
+              <div
+                v-for="member in draftStore.cachedMembers"
+                :key="member.userId"
+                class="flex items-center justify-between p-2 bg-surface-secondary rounded-md"
+              >
+                <div class="flex items-center gap-2">
+                  <UserAvatar :user="getUserById(member.userId)" size="sm" />
+                  <span class="text-sm text-content">{{ getUserById(member.userId)?.name || getUserById(member.userId)?.username }}</span>
+                  <span class="text-xs text-content-tertiary px-1.5 py-0.5 bg-surface rounded">
+                    {{ member.role === 'project-manager' ? '管理員' : member.role === 'project-member' ? '成員' : '檢視者' }}
+                  </span>
+                </div>
+                <button
+                  @click="removeMember(member.userId)"
+                  class="text-content-tertiary hover:text-red-500 transition-colors"
+                >
+                  <ph-icon icon="xmark" class="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+            <div v-else class="text-sm text-content-tertiary text-center py-4">
+              尚未新增成員
+            </div>
+          </div>
+        </div>
+
+        <!-- 類別管理 -->
+        <div class="settings-card">
+          <div class="px-4 py-3 border-b border-edge">
+            <h3 class="text-base font-semibold text-content">類別</h3>
+            <p class="text-xs text-content-tertiary mt-0.5">專案建立後將自動建立這些類別</p>
+          </div>
+          <div class="p-4 space-y-3">
+            <!-- 新增類別表單 -->
+            <div class="flex gap-2">
+              <input
+                v-model="newCategoryName"
+                type="text"
+                placeholder="類別名稱"
+                class="input text-sm flex-1"
+              />
+              <input
+                v-model="newCategoryColor"
+                type="text"
+                placeholder="顏色（選填）"
+                class="input text-sm w-24"
+              />
+              <button
+                @click="addCategory"
+                :disabled="!newCategoryName.trim()"
+                class="btn-secondary px-3"
+              >
+                <ph-icon icon="plus" class="w-4 h-4" />
+              </button>
+            </div>
+            <!-- 類別列表 -->
+            <div v-if="draftStore.cachedCategories.length > 0" class="space-y-2">
+              <div
+                v-for="(category, index) in draftStore.cachedCategories"
+                :key="index"
+                class="flex items-center justify-between p-2 bg-surface-secondary rounded-md"
+              >
+                <span class="text-sm text-content">{{ category.name }}</span>
+                <button
+                  @click="removeCategory(index)"
+                  class="text-content-tertiary hover:text-red-500 transition-colors"
+                >
+                  <ph-icon icon="xmark" class="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+            <div v-else class="text-sm text-content-tertiary text-center py-4">
+              尚未新增類別
+            </div>
+          </div>
+        </div>
+
+        <!-- 欄位管理 -->
+        <div class="settings-card">
+          <div class="px-4 py-3 border-b border-edge">
+            <h3 class="text-base font-semibold text-content">欄位</h3>
+            <p class="text-xs text-content-tertiary mt-0.5">專案建立後將自動建立這些欄位</p>
+          </div>
+          <div class="p-4 space-y-3">
+            <!-- 新增欄位表單 -->
+            <div class="flex gap-2">
+              <input
+                v-model="newColumnTitle"
+                type="text"
+                placeholder="欄位名稱"
+                class="input text-sm flex-1"
+              />
+              <input
+                v-model.number="newColumnLimit"
+                type="number"
+                min="0"
+                placeholder="WIP 限制"
+                class="input text-sm w-24"
+              />
+              <button
+                @click="addColumn"
+                :disabled="!newColumnTitle.trim()"
+                class="btn-secondary px-3"
+              >
+                <ph-icon icon="plus" class="w-4 h-4" />
+              </button>
+            </div>
+            <!-- 欄位列表 -->
+            <div v-if="draftStore.cachedColumns.length > 0" class="space-y-2">
+              <div
+                v-for="(column, index) in draftStore.cachedColumns"
+                :key="index"
+                class="flex items-center justify-between p-2 bg-surface-secondary rounded-md"
+              >
+                <div class="flex items-center gap-2">
+                  <span class="text-sm text-content">{{ column.title }}</span>
+                  <span v-if="column.taskLimit > 0" class="text-xs text-content-tertiary px-1.5 py-0.5 bg-surface rounded">
+                    WIP: {{ column.taskLimit }}
+                  </span>
+                </div>
+                <button
+                  @click="removeColumn(index)"
+                  class="text-content-tertiary hover:text-red-500 transition-colors"
+                >
+                  <ph-icon icon="xmark" class="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+            <div v-else class="text-sm text-content-tertiary text-center py-4">
+              尚未新增欄位（將使用預設欄位）
+            </div>
+          </div>
+        </div>
+
+        <!-- 泳道管理 -->
+        <div class="settings-card">
+          <div class="px-4 py-3 border-b border-edge">
+            <h3 class="text-base font-semibold text-content">泳道</h3>
+            <p class="text-xs text-content-tertiary mt-0.5">專案建立後將自動建立這些泳道</p>
+          </div>
+          <div class="p-4 space-y-3">
+            <!-- 新增泳道表單 -->
+            <div class="flex gap-2">
+              <input
+                v-model="newSwimlaneName"
+                type="text"
+                placeholder="泳道名稱"
+                class="input text-sm flex-1"
+              />
+              <button
+                @click="addSwimlane"
+                :disabled="!newSwimlaneName.trim()"
+                class="btn-secondary px-3"
+              >
+                <ph-icon icon="plus" class="w-4 h-4" />
+              </button>
+            </div>
+            <!-- 泳道列表 -->
+            <div v-if="draftStore.cachedSwimlanes.length > 0" class="space-y-2">
+              <div
+                v-for="(swimlane, index) in draftStore.cachedSwimlanes"
+                :key="index"
+                class="flex items-center justify-between p-2 bg-surface-secondary rounded-md"
+              >
+                <span class="text-sm text-content">{{ swimlane.name }}</span>
+                <button
+                  @click="removeSwimlane(index)"
+                  class="text-content-tertiary hover:text-red-500 transition-colors"
+                >
+                  <ph-icon icon="xmark" class="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+            <div v-else class="text-sm text-content-tertiary text-center py-4">
+              尚未新增泳道（將使用預設泳道）
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>
+
+<style scoped>
+@reference "@/styles/main.css";
+
+.settings-card {
+  @apply bg-surface rounded-xl border border-edge overflow-hidden;
+}
+
+/* Dropdown Transition */
+.dropdown-enter-active {
+  transition: all 0.15s ease-out;
+}
+
+.dropdown-leave-active {
+  transition: all 0.1s ease-in;
+}
+
+.dropdown-enter-from,
+.dropdown-leave-to {
+  opacity: 0;
+  transform: translateY(-0.25rem);
+}
+</style>

--- a/src/views/ProjectCreateView.vue
+++ b/src/views/ProjectCreateView.vue
@@ -635,6 +635,7 @@ onUnmounted(() => {
                 <option value="project-viewer">檢視者</option>
               </select>
               <button
+                type="button"
                 @click="addMember"
                 :disabled="!newMemberUserId"
                 class="btn-secondary px-3"
@@ -657,6 +658,7 @@ onUnmounted(() => {
                   </span>
                 </div>
                 <button
+                  type="button"
                   @click="removeMember(member.userId)"
                   class="text-content-tertiary hover:text-red-500 transition-colors"
                 >
@@ -692,6 +694,7 @@ onUnmounted(() => {
                 class="input text-sm w-24"
               />
               <button
+                type="button"
                 @click="addCategory"
                 :disabled="!newCategoryName.trim()"
                 class="btn-secondary px-3"
@@ -708,6 +711,7 @@ onUnmounted(() => {
               >
                 <span class="text-sm text-content">{{ category.name }}</span>
                 <button
+                  type="button"
                   @click="removeCategory(index)"
                   class="text-content-tertiary hover:text-red-500 transition-colors"
                 >
@@ -744,6 +748,7 @@ onUnmounted(() => {
                 class="input text-sm w-24"
               />
               <button
+                type="button"
                 @click="addColumn"
                 :disabled="!newColumnTitle.trim()"
                 class="btn-secondary px-3"
@@ -765,6 +770,7 @@ onUnmounted(() => {
                   </span>
                 </div>
                 <button
+                  type="button"
                   @click="removeColumn(index)"
                   class="text-content-tertiary hover:text-red-500 transition-colors"
                 >
@@ -794,6 +800,7 @@ onUnmounted(() => {
                 class="input text-sm flex-1"
               />
               <button
+                type="button"
                 @click="addSwimlane"
                 :disabled="!newSwimlaneName.trim()"
                 class="btn-secondary px-3"
@@ -810,6 +817,7 @@ onUnmounted(() => {
               >
                 <span class="text-sm text-content">{{ swimlane.name }}</span>
                 <button
+                  type="button"
                   @click="removeSwimlane(index)"
                   class="text-content-tertiary hover:text-red-500 transition-colors"
                 >


### PR DESCRIPTION
## Summary

實作 Issue #75 - 新增專案完整建立頁面，並在建立專案燈箱中加入展開按鈕。

### 功能特色
- 新增 `/projects/new` 路由的完整專案建立頁面
- 在建立專案燈箱中新增展開按鈕，可跳轉至完整建立頁面
- 燈箱中已填寫的資料會透過 store 帶入完整頁面
- 完整頁面支援管理區塊（成員、類別、欄位、泳道）的預先設定
- 建立專案時會依序建立專案本體及緩存的管理資料

### 變更內容
- `src/stores/projectDraft.ts` - 新增專案草稿 store，用於緩存建立資料
- `src/components/CreateProjectModal.vue` - 新增展開按鈕及資料儲存功能
- `src/views/ProjectCreateView.vue` - 新增完整專案建立頁面
- `src/router/index.ts` - 新增路由設定
- 新增三個測試檔案共 55 個測試案例

### 技術細節
- 使用 Pinia store 管理草稿狀態
- 使用 computed 雙向綁定實現 store 與表單的同步
- 管理區塊的資料先緩存在 store 中，建立專案後再依序呼叫 API

## Test plan
- [x] 執行 `npm test` 確認 647 個測試全部通過
- [ ] 手動測試：開啟建立專案燈箱，填寫資料後點擊展開按鈕
- [ ] 手動測試：在完整頁面新增類別、欄位、泳道
- [ ] 手動測試：建立專案並確認跳轉至看板頁面
- [ ] 手動測試：確認建立的專案包含預設的類別、欄位、泳道

Closes #75