### PR TITLE
refactor(ui): 統一使用 UserAvatar 元件顯示使用者頭像

### DIFF
--- a/src/__tests__/AdminUsersView.test.ts
+++ b/src/__tests__/AdminUsersView.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import AdminUsersView from '@/views/AdminUsersView.vue'
+import { useAuthStore } from '@/stores/auth'
+
+// Mock fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Create a mock router
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', component: { template: '<div>Home</div>' } },
+    { path: '/admin/users', name: 'admin-users', component: AdminUsersView }
+  ]
+})
+
+// Mock PhIcon component
+const PhIcon = {
+  name: 'PhIcon',
+  props: ['icon', 'weight'],
+  template: '<span :data-icon="icon"></span>'
+}
+
+describe('AdminUsersView', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    mockFetch.mockReset()
+
+    // Setup auth store
+    const authStore = useAuthStore()
+    authStore._setTestCredentials({
+      apiUrl: 'http://localhost/jsonrpc.php',
+      username: 'admin',
+      password: 'admin'
+    })
+    authStore.user = {
+      id: 1,
+      name: 'Admin',
+      username: 'admin',
+      role: 'app-admin'
+    }
+
+    // Mock API responses for users list
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        jsonrpc: '2.0',
+        id: 1,
+        result: [
+          { id: 1, name: 'Admin User', username: 'admin', email: 'admin@test.com', role: 'app-admin', is_active: 1 },
+          { id: 2, name: 'John Doe', username: 'john', email: 'john@test.com', role: 'app-user', is_active: 1 }
+        ]
+      })
+    })
+
+    await router.push('/admin/users')
+    await router.isReady()
+  })
+
+  function mountView() {
+    return mount(AdminUsersView, {
+      global: {
+        plugins: [router],
+        stubs: {
+          PhIcon,
+          UserAvatar: true
+        }
+      }
+    })
+  }
+
+  describe('user list avatars', () => {
+    it('should use UserAvatar component for user avatars', async () => {
+      const wrapper = mountView()
+      await flushPromises()
+
+      const avatars = wrapper.findAllComponents({ name: 'UserAvatar' })
+      expect(avatars.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('should pass user data to UserAvatar', async () => {
+      const wrapper = mountView()
+      await flushPromises()
+
+      const avatars = wrapper.findAllComponents({ name: 'UserAvatar' })
+      const adminAvatar = avatars.find(a =>
+        a.props('user')?.name === 'Admin User' ||
+        a.props('name') === 'Admin User'
+      )
+      expect(adminAvatar).toBeDefined()
+    })
+
+    it('should use sm size for user list avatars', async () => {
+      const wrapper = mountView()
+      await flushPromises()
+
+      const avatars = wrapper.findAllComponents({ name: 'UserAvatar' })
+      avatars.forEach(avatar => {
+        expect(avatar.props('size')).toBe('sm')
+      })
+    })
+  })
+})

--- a/src/__tests__/ProjectActivityView.test.ts
+++ b/src/__tests__/ProjectActivityView.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import ProjectActivityView from '@/views/ProjectActivityView.vue'
+import { useBoardStore } from '@/stores/board'
+import { useAuthStore } from '@/stores/auth'
+import { useNotificationsStore } from '@/stores/notifications'
+
+// Mock fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Create a mock router
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', component: { template: '<div>Home</div>' } },
+    { path: '/projects/:id/activity', name: 'project-activity', component: ProjectActivityView }
+  ]
+})
+
+// Mock PhIcon component
+const PhIcon = {
+  name: 'PhIcon',
+  props: ['icon', 'weight'],
+  template: '<span :data-icon="icon"></span>'
+}
+
+describe('ProjectActivityView', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    mockFetch.mockReset()
+
+    // Setup auth store
+    const authStore = useAuthStore()
+    authStore._setTestCredentials({
+      apiUrl: 'http://localhost/jsonrpc.php',
+      username: 'admin',
+      password: 'admin'
+    })
+
+    // Mock API responses to return empty results
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        jsonrpc: '2.0',
+        id: 1,
+        result: []
+      })
+    })
+
+    await router.push('/projects/1/activity')
+    await router.isReady()
+  })
+
+  describe('UserAvatar integration', () => {
+    it('should import UserAvatar component', async () => {
+      // Verify that the component file imports UserAvatar
+      const componentModule = await import('@/views/ProjectActivityView.vue')
+      expect(componentModule.default).toBeDefined()
+    })
+
+    it('should render without errors', () => {
+      const boardStore = useBoardStore()
+      boardStore.project = { id: 1, name: 'Test', is_active: 1 }
+
+      const wrapper = mount(ProjectActivityView, {
+        global: {
+          plugins: [router],
+          stubs: {
+            PhIcon,
+            UserAvatar: true,
+            SearchModal: true
+          }
+        }
+      })
+
+      expect(wrapper.exists()).toBe(true)
+    })
+  })
+})

--- a/src/__tests__/ProjectOverviewView.test.ts
+++ b/src/__tests__/ProjectOverviewView.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import ProjectOverviewView from '@/views/ProjectOverviewView.vue'
+import { useBoardStore } from '@/stores/board'
+import { useAuthStore } from '@/stores/auth'
+import { useMembersStore } from '@/stores/members'
+import { useProjectsStore } from '@/stores/projects'
+import { useAnalyticsStore } from '@/stores/analytics'
+
+// Mock fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Create a mock router
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', component: { template: '<div>Home</div>' } },
+    { path: '/projects/:id/overview', name: 'project-overview', component: ProjectOverviewView },
+    { path: '/projects/:id/activity', name: 'project-activity', component: { template: '<div>Activity</div>' } },
+    { path: '/projects/:id', name: 'project-list', component: { template: '<div>List</div>' } }
+  ]
+})
+
+// Mock PhIcon component
+const PhIcon = {
+  name: 'PhIcon',
+  props: ['icon', 'weight'],
+  template: '<span :data-icon="icon"></span>'
+}
+
+describe('ProjectOverviewView', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    mockFetch.mockReset()
+
+    // Setup auth store
+    const authStore = useAuthStore()
+    authStore._setTestCredentials({
+      apiUrl: 'http://localhost/jsonrpc.php',
+      username: 'admin',
+      password: 'admin'
+    })
+
+    // Mock API responses to return empty results
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        jsonrpc: '2.0',
+        id: 1,
+        result: []
+      })
+    })
+
+    await router.push('/projects/1/overview')
+    await router.isReady()
+  })
+
+  describe('UserAvatar integration', () => {
+    it('should import UserAvatar component', async () => {
+      const componentModule = await import('@/views/ProjectOverviewView.vue')
+      expect(componentModule.default).toBeDefined()
+    })
+
+    it('should render without errors', () => {
+      const boardStore = useBoardStore()
+      boardStore.project = { id: 1, name: 'Test', is_active: 1 }
+      boardStore.columns = []
+
+      const wrapper = mount(ProjectOverviewView, {
+        global: {
+          plugins: [router],
+          stubs: {
+            PhIcon,
+            UserAvatar: true
+          }
+        }
+      })
+
+      expect(wrapper.exists()).toBe(true)
+    })
+  })
+})

--- a/src/__tests__/TaskCard.test.ts
+++ b/src/__tests__/TaskCard.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TaskCard from '@/components/TaskCard.vue'
+import UserAvatar from '@/components/UserAvatar.vue'
+
+// Mock PhIcon component
+const PhIcon = {
+  name: 'PhIcon',
+  props: ['icon'],
+  template: '<span :data-icon="icon"></span>'
+}
+
+describe('TaskCard', () => {
+  const baseTask = {
+    id: 1,
+    title: 'Test Task',
+    color_id: 'blue',
+    column_id: 1,
+    project_id: 1,
+    position: 1,
+    is_active: 1,
+    date_creation: 1704067200,
+    date_modification: 1704067200
+  }
+
+  function mountCard(task = baseTask) {
+    return mount(TaskCard, {
+      props: { task },
+      global: {
+        stubs: {
+          PhIcon,
+          UserAvatar: true
+        }
+      }
+    })
+  }
+
+  describe('assignee avatar', () => {
+    it('should use UserAvatar component when owner is assigned', () => {
+      const task = {
+        ...baseTask,
+        owner_id: 1,
+        owner_name: 'John Doe',
+        owner_username: 'johndoe'
+      }
+      const wrapper = mountCard(task)
+
+      const avatar = wrapper.findComponent({ name: 'UserAvatar' })
+      expect(avatar.exists()).toBe(true)
+    })
+
+    it('should pass owner data to UserAvatar', () => {
+      const task = {
+        ...baseTask,
+        owner_id: 1,
+        owner_name: 'John Doe',
+        owner_username: 'johndoe'
+      }
+      const wrapper = mountCard(task)
+
+      const avatar = wrapper.findComponent({ name: 'UserAvatar' })
+      expect(avatar.props('name')).toBe('John Doe')
+    })
+
+    it('should use owner_username when owner_name is not available', () => {
+      const task = {
+        ...baseTask,
+        owner_id: 1,
+        owner_username: 'johndoe'
+      }
+      const wrapper = mountCard(task)
+
+      const avatar = wrapper.findComponent({ name: 'UserAvatar' })
+      expect(avatar.props('name')).toBe('johndoe')
+    })
+
+    it('should not render UserAvatar when no owner is assigned', () => {
+      const wrapper = mountCard(baseTask)
+
+      const avatar = wrapper.findComponent({ name: 'UserAvatar' })
+      expect(avatar.exists()).toBe(false)
+    })
+
+    it('should use xs size for avatar in card', () => {
+      const task = {
+        ...baseTask,
+        owner_id: 1,
+        owner_name: 'John Doe'
+      }
+      const wrapper = mountCard(task)
+
+      const avatar = wrapper.findComponent({ name: 'UserAvatar' })
+      expect(avatar.props('size')).toBe('xs')
+    })
+  })
+})

--- a/src/__tests__/UserDropdown.test.ts
+++ b/src/__tests__/UserDropdown.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import UserDropdown from '@/components/header/UserDropdown.vue'
+import { useAuthStore } from '@/stores/auth'
+
+// Mock fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Create a mock router
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', component: { template: '<div>Home</div>' } },
+    { path: '/settings', name: 'user-settings', component: { template: '<div>Settings</div>' } },
+    { path: '/login', name: 'login', component: { template: '<div>Login</div>' } }
+  ]
+})
+
+// Mock PhIcon component
+const PhIcon = {
+  name: 'PhIcon',
+  props: ['icon'],
+  template: '<span :data-icon="icon"></span>'
+}
+
+describe('UserDropdown', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    mockFetch.mockReset()
+
+    // Setup auth store with user
+    const authStore = useAuthStore()
+    authStore._setTestCredentials({
+      apiUrl: 'http://localhost/jsonrpc.php',
+      username: 'admin',
+      password: 'admin'
+    })
+    authStore.user = {
+      id: 1,
+      name: '管理員測試',
+      username: 'admin',
+      role: 'app-admin',
+      email: 'admin@example.com'
+    }
+
+    // Mock API responses
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        jsonrpc: '2.0',
+        id: 1,
+        result: null
+      })
+    })
+
+    await router.push('/')
+    await router.isReady()
+  })
+
+  function mountDropdown() {
+    return mount(UserDropdown, {
+      global: {
+        plugins: [router],
+        stubs: {
+          PhIcon,
+          UserAvatar: true
+        }
+      }
+    })
+  }
+
+  describe('avatar display', () => {
+    it('should use UserAvatar component for user avatar', () => {
+      const wrapper = mountDropdown()
+
+      const avatar = wrapper.findComponent({ name: 'UserAvatar' })
+      expect(avatar.exists()).toBe(true)
+    })
+
+    it('should pass user data to UserAvatar', () => {
+      const wrapper = mountDropdown()
+
+      const avatar = wrapper.findComponent({ name: 'UserAvatar' })
+      expect(avatar.props('user')).toBeDefined()
+      expect(avatar.props('user').name).toBe('管理員測試')
+    })
+
+    it('should pass avatar image data when available', async () => {
+      const authStore = useAuthStore()
+      authStore.avatarData = 'base64encodedimage'
+
+      const wrapper = mountDropdown()
+
+      const avatar = wrapper.findComponent({ name: 'UserAvatar' })
+      expect(avatar.props('imageUrl')).toContain('base64encodedimage')
+    })
+
+    it('should use sm size for dropdown trigger avatar', () => {
+      const wrapper = mountDropdown()
+
+      // Find the trigger button's avatar (first one)
+      const avatars = wrapper.findAllComponents({ name: 'UserAvatar' })
+      expect(avatars.length).toBeGreaterThan(0)
+      expect(avatars[0].props('size')).toBe('sm')
+    })
+
+    it('should use md size for dropdown menu avatar', async () => {
+      const wrapper = mountDropdown()
+
+      // Click to open dropdown
+      const trigger = wrapper.find('button')
+      await trigger.trigger('click')
+
+      // Find all avatars - the second one should be in the menu
+      const avatars = wrapper.findAllComponents({ name: 'UserAvatar' })
+      expect(avatars.length).toBe(2)
+      expect(avatars[1].props('size')).toBe('md')
+    })
+  })
+})

--- a/src/components/TaskCard.vue
+++ b/src/components/TaskCard.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
 import type { Task } from '@/types'
+import UserAvatar from '@/components/UserAvatar.vue'
+import { computed } from 'vue'
 
-defineProps<{
+const props = defineProps<{
   task: Task
 }>()
 
 const emit = defineEmits<{
   click: [task: Task]
 }>()
+
+const ownerDisplayName = computed(() => {
+  return props.task.owner_name || props.task.owner_username || null
+})
 
 const colorClasses: Record<string, string> = {
   yellow: 'border-l-yellow-500 bg-yellow-50',
@@ -66,10 +72,8 @@ function formatDate(timestamp?: number): string {
     <!-- Meta info -->
     <div class="mt-2 flex items-center justify-between text-xs text-gray-500">
       <!-- Assignee -->
-      <div v-if="task.owner_id" class="flex items-center">
-        <div class="w-5 h-5 rounded-full bg-gray-300 flex items-center justify-center text-[10px] text-white">
-          {{ task.owner_id }}
-        </div>
+      <div v-if="task.owner_id && ownerDisplayName" class="flex items-center">
+        <UserAvatar :name="ownerDisplayName" size="xs" />
       </div>
       <div v-else></div>
 

--- a/src/components/header/UserDropdown.vue
+++ b/src/components/header/UserDropdown.vue
@@ -3,7 +3,8 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useTheme, type ThemeName, THEMES } from '@/composables/useTheme'
-import { getAvatarColor, getAvatarInitial, getUserDisplayName } from '@/utils/avatar'
+import { getUserDisplayName } from '@/utils/avatar'
+import UserAvatar from '@/components/UserAvatar.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -13,11 +14,15 @@ const isOpen = ref(false)
 const showThemeMenu = ref(false)
 
 const displayName = computed(() => getUserDisplayName(authStore.user))
-const avatarInitial = computed(() => getAvatarInitial(displayName.value))
-const avatarBgColor = computed(() => getAvatarColor(displayName.value))
 
-// 直接使用 store 的頭像資料（與其他元件同步）
-const avatarImageData = computed(() => authStore.avatarData)
+// 頭像圖片 URL（用於 UserAvatar）
+const avatarImageUrl = computed(() => {
+  const data = authStore.avatarData
+  return data ? `data:image/png;base64,${data}` : null
+})
+
+// 使用者物件（用於 UserAvatar）
+const userForAvatar = computed(() => authStore.user)
 
 // 檢查是否為管理員
 const isAdmin = computed(() => authStore.user?.role === 'app-admin')
@@ -90,19 +95,7 @@ onUnmounted(() => {
       class="flex items-center gap-2 p-1.5 rounded-lg hover:bg-surface-hover transition-colors"
     >
       <!-- Avatar -->
-      <img
-        v-if="avatarImageData"
-        :src="`data:image/png;base64,${avatarImageData}`"
-        :alt="displayName"
-        class="w-8 h-8 rounded-full object-cover"
-      />
-      <div
-        v-else
-        class="w-8 h-8 rounded-full text-white flex items-center justify-center text-sm font-medium"
-        :style="{ backgroundColor: avatarBgColor }"
-      >
-        {{ avatarInitial }}
-      </div>
+      <UserAvatar :user="userForAvatar" :image-url="avatarImageUrl" size="sm" />
       <!-- Name (hidden on mobile) -->
       <span class="hidden sm:inline text-sm text-content">{{ displayName }}</span>
       <!-- Chevron -->
@@ -129,19 +122,7 @@ onUnmounted(() => {
         <!-- User Info Header -->
         <div class="px-4 py-3 border-b border-edge bg-surface-secondary">
           <div class="flex items-center gap-3">
-            <img
-              v-if="avatarImageData"
-              :src="`data:image/png;base64,${avatarImageData}`"
-              :alt="displayName"
-              class="w-10 h-10 rounded-full object-cover"
-            />
-            <div
-              v-else
-              class="w-10 h-10 rounded-full text-white flex items-center justify-center text-base font-medium"
-              :style="{ backgroundColor: avatarBgColor }"
-            >
-              {{ avatarInitial }}
-            </div>
+            <UserAvatar :user="userForAvatar" :image-url="avatarImageUrl" size="md" />
             <div class="flex-1 min-w-0">
               <p class="text-sm font-medium text-content truncate">{{ displayName }}</p>
               <p class="text-xs text-content-tertiary truncate">{{ authStore.user?.email || authStore.user?.username }}</p>

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -65,6 +65,8 @@ export interface Task {
   color_id: string
   priority: number
   owner_id: number
+  owner_name?: string | null
+  owner_username?: string | null
   creator_id: number
   date_creation: number
   date_modification: number

--- a/src/views/AdminGroupsView.vue
+++ b/src/views/AdminGroupsView.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useGroupsStore } from '@/stores/groups'
 import { useUsersStore } from '@/stores/users'
 import { useToast } from '@/stores/toast'
-import { getAvatarColor, getAvatarInitial, getUserDisplayName } from '@/utils/avatar'
+import UserAvatar from '@/components/UserAvatar.vue'
 import type { Group, User } from '@/types'
 
 const groupsStore = useGroupsStore()
@@ -401,12 +401,7 @@ const handleRemoveMember = async (userId: number) => {
                     class="flex items-center justify-between p-3 bg-surface-secondary rounded-lg"
                   >
                     <div class="flex items-center gap-3">
-                      <div
-                        class="w-8 h-8 rounded-full flex items-center justify-center text-white text-xs font-medium"
-                        :style="{ backgroundColor: getAvatarColor(getUserDisplayName(member)) }"
-                      >
-                        {{ getAvatarInitial(getUserDisplayName(member)) }}
-                      </div>
+                      <UserAvatar :user="member" size="sm" />
                       <div>
                         <p class="font-medium text-content text-sm">{{ member.name || member.username }}</p>
                         <p class="text-xs text-content-tertiary">@{{ member.username }}</p>

--- a/src/views/AdminUsersView.vue
+++ b/src/views/AdminUsersView.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useUsersStore } from '@/stores/users'
 import { useToast } from '@/stores/toast'
-import { getAvatarColor, getAvatarInitial, getUserDisplayName } from '@/utils/avatar'
+import UserAvatar from '@/components/UserAvatar.vue'
 import type { User } from '@/types'
 
 const authStore = useAuthStore()
@@ -327,12 +327,7 @@ const handleRemoveUser = async (user: User) => {
             >
               <td class="table-cell">
                 <div class="flex items-center gap-3">
-                  <div
-                    class="w-8 h-8 rounded-full flex items-center justify-center text-white text-xs font-medium"
-                    :style="{ backgroundColor: getAvatarColor(getUserDisplayName(user)) }"
-                  >
-                    {{ getAvatarInitial(getUserDisplayName(user)) }}
-                  </div>
+                  <UserAvatar :user="user" size="sm" />
                   <div>
                     <p class="font-medium text-content">{{ user.name || user.username }}</p>
                     <p class="text-xs text-content-tertiary">@{{ user.username }}</p>

--- a/src/views/GroupsManagementView.vue
+++ b/src/views/GroupsManagementView.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGroupsStore } from '@/stores/groups'
 import { useUsersStore } from '@/stores/users'
-import { getAvatarColor, getAvatarInitial, getUserDisplayName } from '@/utils/avatar'
+import UserAvatar from '@/components/UserAvatar.vue'
 import SearchModal from '@/components/SearchModal.vue'
 import type { Group, User, Task } from '@/types'
 
@@ -470,12 +470,7 @@ const handleSearchSelect = (task: Task) => {
                     class="flex items-center justify-between p-3 bg-surface-tertiary rounded-lg"
                   >
                     <div class="flex items-center gap-3">
-                      <div
-                        class="w-8 h-8 rounded-full flex items-center justify-center text-white text-xs font-medium"
-                        :style="{ backgroundColor: getAvatarColor(getUserDisplayName(member)) }"
-                      >
-                        {{ getAvatarInitial(getUserDisplayName(member)) }}
-                      </div>
+                      <UserAvatar :user="member" size="sm" />
                       <div>
                         <div class="font-medium text-content text-sm">
                           {{ member.name || member.username }}

--- a/src/views/ProjectActivityView.vue
+++ b/src/views/ProjectActivityView.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, watch, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useBoardStore } from '@/stores/board'
 import { useNotificationsStore } from '@/stores/notifications'
-import { getAvatarColor, getAvatarInitial } from '@/utils/avatar'
+import UserAvatar from '@/components/UserAvatar.vue'
 import SearchModal from '@/components/SearchModal.vue'
 import type { Activity, Task } from '@/types'
 
@@ -123,10 +123,6 @@ function getTaskTitle(activity: Activity): string {
 
 function getAuthorName(activity: Activity): string {
   return activity.author_name || activity.author_username || '未知使用者'
-}
-
-function getAuthorInitial(activity: Activity): string {
-  return getAvatarInitial(getAuthorName(activity))
 }
 
 function getAssigneeName(activity: Activity): string | null {
@@ -319,12 +315,7 @@ const groupedActivities = computed(() => {
 
                   <!-- Author avatar -->
                   <div class="flex-shrink-0">
-                    <div
-                      class="w-8 h-8 rounded-full flex items-center justify-center text-white text-sm font-medium"
-                      :style="{ backgroundColor: getAvatarColor(getAuthorName(activity)) }"
-                    >
-                      {{ getAuthorInitial(activity) }}
-                    </div>
+                    <UserAvatar :name="getAuthorName(activity)" size="sm" />
                   </div>
                 </div>
               </div>

--- a/src/views/ProjectOverviewView.vue
+++ b/src/views/ProjectOverviewView.vue
@@ -103,12 +103,7 @@
                   class="flex gap-3 py-3 border-b border-edge last:border-0 animate-slideIn"
                   :style="{ animationDelay: `${index * 50}ms` }"
                 >
-                  <div
-                    class="w-8 h-8 rounded-full flex items-center justify-center text-white text-xs font-semibold flex-shrink-0"
-                    :style="{ backgroundColor: getAvatarColor(activity.author_username || '') }"
-                  >
-                    {{ getInitial(activity.author_username || '') }}
-                  </div>
+                  <UserAvatar :name="activity.author_name || activity.author_username" size="sm" />
                   <div class="flex-1 min-w-0">
                     <div class="flex flex-wrap items-center gap-1 text-sm">
                       <span class="font-medium text-content">{{ activity.author_username }}</span>
@@ -182,12 +177,7 @@
                 class="flex items-center gap-2 px-2 py-1.5 bg-surface-secondary rounded-lg"
                 :title="getMemberName(member)"
               >
-                <div
-                  class="w-6 h-6 rounded-full flex items-center justify-center text-white text-xs font-medium flex-shrink-0"
-                  :style="{ backgroundColor: getAvatarColor(getMemberName(member)) }"
-                >
-                  {{ getInitial(getMemberName(member)) }}
-                </div>
+                <UserAvatar :name="getMemberName(member)" size="xs" />
                 <span class="text-sm text-content truncate max-w-24">{{ getMemberName(member) }}</span>
               </div>
             </div>
@@ -224,7 +214,7 @@ import { useBoardStore } from '@/stores/board'
 import { useMembersStore } from '@/stores/members'
 import { useProjectsStore } from '@/stores/projects'
 import { useAnalyticsStore } from '@/stores/analytics'
-import { getAvatarColor, getAvatarInitial } from '@/utils/avatar'
+import UserAvatar from '@/components/UserAvatar.vue'
 
 const route = useRoute()
 const boardStore = useBoardStore()
@@ -303,10 +293,6 @@ function getMemberName(member: unknown): string {
 function getColumnPercentage(count: number | undefined): number {
   if (totalTasks.value === 0) return 0
   return ((count || 0) / totalTasks.value) * 100
-}
-
-function getInitial(name: string | undefined): string {
-  return getAvatarInitial(name)
 }
 
 function formatEventName(eventName: string): string {

--- a/src/views/UsersManagementView.vue
+++ b/src/views/UsersManagementView.vue
@@ -3,7 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useUsersStore } from '@/stores/users'
-import { getAvatarColor, getAvatarInitial, getUserDisplayName } from '@/utils/avatar'
+import UserAvatar from '@/components/UserAvatar.vue'
 import SearchModal from '@/components/SearchModal.vue'
 import type { User, Task } from '@/types'
 
@@ -299,12 +299,7 @@ const handleSearchSelect = (task: Task) => {
               <div v-if="editingUserId !== user.id" class="flex items-center justify-between">
                 <div class="flex items-center gap-4">
                   <!-- Avatar -->
-                  <div
-                    class="w-10 h-10 rounded-full flex items-center justify-center text-white text-sm font-medium"
-                    :style="{ backgroundColor: getAvatarColor(getUserDisplayName(user)) }"
-                  >
-                    {{ getAvatarInitial(getUserDisplayName(user)) }}
-                  </div>
+                  <UserAvatar :user="user" size="md" />
 
                   <!-- User info -->
                   <div>


### PR DESCRIPTION
## Summary

- 將所有直接使用 `getAvatarColor`/`getAvatarInitial` 工具函數顯示頭像的地方，統一改用 `UserAvatar` 元件
- 確保頭像顯示一致性並支援實際頭像圖片

## 變更內容

### 元件整合
- **TaskCard**: 改用 UserAvatar 顯示指派人頭像（新增 `owner_name`/`owner_username` 支援）
- **UserDropdown**: 改用 UserAvatar 顯示當前使用者頭像
- **ProjectActivityView**: 改用 UserAvatar 顯示活動作者頭像
- **ProjectOverviewView**: 改用 UserAvatar 顯示活動與成員頭像
- **AdminUsersView**: 改用 UserAvatar 顯示使用者列表頭像
- **AdminGroupsView**: 改用 UserAvatar 顯示群組成員頭像
- **UsersManagementView**: 改用 UserAvatar 顯示使用者頭像
- **GroupsManagementView**: 改用 UserAvatar 顯示群組成員頭像

### 類型更新
- Task 介面新增 `owner_name` 和 `owner_username` 可選欄位

### 未整合（保持原樣）
- **UserSettingsView**: 因包含頭像上傳/移除功能，需要特殊的 UI 處理（載入狀態、hover overlay 等），保持原有實作

## Test plan

- [x] 所有 663 個測試通過
- [ ] 瀏覽器驗證 TaskCard 指派人頭像顯示
- [ ] 瀏覽器驗證 UserDropdown 頭像顯示
- [ ] 瀏覽器驗證專案活動頁面頭像顯示
- [ ] 瀏覽器驗證專案總覽頁面頭像顯示
- [ ] 瀏覽器驗證管理員使用者頁面頭像顯示
- [ ] 瀏覽器驗證管理員群組頁面頭像顯示

Closes #77